### PR TITLE
left right key navigation added

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -145,6 +145,10 @@ const config = {
         respectPrefersColorScheme: false,
       },
     }),
+  
+    clientModules:[
+      require.resolve("./src/js/keyboard-shortcuts.js")
+    ]
 };
 
 export default config;

--- a/src/js/keyboard-shortcuts.js
+++ b/src/js/keyboard-shortcuts.js
@@ -1,0 +1,35 @@
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
+
+function navigatePage(direction) {
+  const navElement = document.querySelector(
+    `.pagination-nav__link--${direction}`
+  );
+  if (navElement) {
+    navElement.click();
+  }
+}
+
+if (ExecutionEnvironment.canUseDOM) {
+  document.addEventListener("keydown", (event) => {
+    
+  // Check if no input is focused
+  if (
+    document.activeElement.tagName !== "INPUT" &&
+    document.activeElement.tagName !== "TEXTAREA"
+  ) {
+    if (event.key === "ArrowLeft") {
+      navigatePage("prev");
+    }
+
+    if (event.key==="ArrowRight") {
+      navigatePage("next");
+    }
+  }
+});
+
+
+}
+
+
+
+


### PR DESCRIPTION
Small quality-of-life change: pressing the right arrow key will navigate to the next page in the documentation and pressing the left arrow key will navigate to the previous.