### PR TITLE
Metamask export private key method updated

### DIFF
--- a/docs/devs/tutorials/Deploy/EVM Contracts/foundryandfractal.md
+++ b/docs/devs/tutorials/Deploy/EVM Contracts/foundryandfractal.md
@@ -67,7 +67,7 @@ Create an .env file
 touch .env
 ```
 
-Add your private key to the .env file. You can obtain your private key from your EVM wallet that you funded with MOVE. For example, if you are using MetaMask, you can find your private key under Settings > Advanced > Export Private Key. Make sure to keep your private key safe and never share it with anyone.
+Add your private key to the .env file. You can obtain your private key from your EVM wallet that you funded with MOVE. For example, if you are using MetaMask, you can find your private key by clicking the three vertical dots next to the account you want to export. Account details > Show private key > Enter your password > Confirm > Hold to reveal Private Key. Make sure to keep your private key safe and never share it with anyone.
 
 `PRIVATE_KEY=<your private key>`
 

--- a/docs/devs/tutorials/Deploy/EVM Contracts/hardhatandfractal.md
+++ b/docs/devs/tutorials/Deploy/EVM Contracts/hardhatandfractal.md
@@ -82,7 +82,7 @@ Create an .env file
 touch .env
 ```
 
-Add your private key to the .env file. You can obtain your private key from your EVM wallet that you funded with MOV. For example, if you are using MetaMask, you can find your private key under Settings > Advanced > Export Private Key. Make sure to keep your private key safe and never share it with anyone.
+Add your private key to the .env file. You can obtain your private key from your EVM wallet that you funded with MOVE. For example, if you are using MetaMask, you can find your private key by clicking the three vertical dots next to the account you want to export. Account details > Show private key > Enter your password > Confirm > Hold to reveal Private Key. Make sure to keep your private key safe and never share it with anyone.
 
 `PRIVATE_KEY=<your private key>`
 


### PR DESCRIPTION
In Metamask private key export example **Settings > Advanced > Export** is old method, updated to new **Account details > Show private key > Enter your password > Confirm > Hold to reveal Private Key**

![image](https://github.com/user-attachments/assets/51d75322-f334-4abd-8f5e-4a76e9ff1150)

Correction Source link - [here](https://support.metamask.io/managing-my-wallet/secret-recovery-phrase-and-private-keys/how-to-export-an-accounts-private-key/#:~:text=Click%20on%20the%20account%20selector,Done'%20to%20close%20the%20screen)