### PR TITLE
Aptos CLI Link corrected.

### DIFF
--- a/docs/devs/tutorials/Deploy/EVM Contracts/foundryandfractal.md
+++ b/docs/devs/tutorials/Deploy/EVM Contracts/foundryandfractal.md
@@ -67,7 +67,7 @@ Create an .env file
 touch .env
 ```
 
-Add your private key to the .env file. You can obtain your private key from your EVM wallet that you funded with MOVE. For example, if you are using MetaMask, you can find your private key under Settings > Advanced > Export Private Key. Make sure to keep your private key safe and never share it with anyone.
+Add your private key to the .env file. You can obtain your private key from your EVM wallet that you funded with MOVE. For example, if you are using MetaMask, you can find your private key by clicking the three vertical dots next to the account you want to export. Account details > Show private key > Enter your password > Confirm > Hold to reveal Private Key. Make sure to keep your private key safe and never share it with anyone.
 
 `PRIVATE_KEY=<your private key>`
 

--- a/docs/devs/tutorials/Deploy/EVM Contracts/hardhatandfractal.md
+++ b/docs/devs/tutorials/Deploy/EVM Contracts/hardhatandfractal.md
@@ -82,7 +82,7 @@ Create an .env file
 touch .env
 ```
 
-Add your private key to the .env file. You can obtain your private key from your EVM wallet that you funded with MOV. For example, if you are using MetaMask, you can find your private key under Settings > Advanced > Export Private Key. Make sure to keep your private key safe and never share it with anyone.
+Add your private key to the .env file. You can obtain your private key from your EVM wallet that you funded with MOVE. For example, if you are using MetaMask, you can find your private key by clicking the three vertical dots next to the account you want to export. Account details > Show private key > Enter your password > Confirm > Hold to reveal Private Key. Make sure to keep your private key safe and never share it with anyone.
 
 `PRIVATE_KEY=<your private key>`
 

--- a/docs/devs/tutorials/Deploy/aptosmodule.md
+++ b/docs/devs/tutorials/Deploy/aptosmodule.md
@@ -8,7 +8,7 @@ sidebar_position: 1
 
 ## Requirements
 
-Make sure to have the [Aptos CLI]((https://aptos.dev/tools/aptos-cli/install-cli/)) installed.
+Make sure to have the [Aptos CLI](https://aptos.dev/tools/aptos-cli/install-cli/) installed.
 
 ## Initialize your Environment
 


### PR DESCRIPTION
In [Aptos Module](https://docs.movementnetwork.xyz/devs/tutorials/Deploy/aptosmodule) in requirement section when we click on Aptos CLI it was showing page not found this is corrected.

![image](https://github.com/user-attachments/assets/0d4afcfb-415e-4dbf-8a77-05aadf101321)
