### PR TITLE
Fix: MOVE Faucet link fixed

### DIFF
--- a/docs/devs/tutorials/Deploy/EVM Contracts/hardhatandfractal.md
+++ b/docs/devs/tutorials/Deploy/EVM Contracts/hardhatandfractal.md
@@ -23,7 +23,7 @@ Before you begin this tutorial, you'll need to install [Hardhat](https://hardhat
 
 ## Fund your wallet with MOVE tokens
 
-Fund an EVM wallet address with some MOVE tokens using our [faucet](/Introduction/faucet). Another method to get MOVE is to bridge from M1 to your EVM wallet using our [bridge](https://evm-bridge.devnet.m1.movementlabs.xyz/#/Faucet). To connect to our testnet and check if you have received the MOVE tokens, you can take the following steps:
+Fund an EVM wallet address with some MOVE tokens using our [faucet](https://faucet.movementlabs.xyz/?network=mevm). Another method to get MOVE is to bridge from M1 to your EVM wallet using our [bridge](https://evm-bridge.devnet.m1.movementlabs.xyz/#/Faucet). To connect to our testnet and check if you have received the MOVE tokens, you can take the following steps:
 
 1. Add the move-evm network to your EVM-compatible wallet.
 


### PR DESCRIPTION
Fixed the MOVE Faucet link. The new link redirects to the movement Network Faucet to get MOVE in you EVM address