### PR TITLE
feat: add multicall contract address to mevm specifications

### DIFF
--- a/docs/devs/networkEndpoints.md
+++ b/docs/devs/networkEndpoints.md
@@ -53,6 +53,7 @@ The MEVM environment is currently accessible through the Imola Devnet.
 | Explorer         | [https://explorer.devnet.imola.movementnetwork.xyz](https://explorer.devnet.imola.movementnetwork.xyz)     |
 | Indexer          | [https://aptos.devnet.imola.movementlabs.xyz/indexer/v1/graphql](https://aptos.devnet.imola.movementlabs.xyz/indexer/v1/graphql) |
 | Subgraph RPC     | [https://mevm2.devnet.imola.movementlabs.xyz/](https://mevm2.devnet.imola.movementlabs.xyz/)     |
+| Multicall | [0x5005A743875A50F80C306d3A6cfAC1C000623658](https://explorer.devnet.imola.movementlabs.xyz/#/account/0x0000000000000000000000005005a743875a50f80c306d3a6cfac1c000623658/resources)
 
 Additional Public EVM Endpoints
 


### PR DESCRIPTION
What I have done:
1. Deployed Multicall3 to MEVM network.
2. Added address to MEVM network confication.

Challenges I faced:
Deterministic deployment didn't work, because the MEVM was giving error of "chainID error" when "sendRawTransaction" RPC method was used.