### PR TITLE
Typo corrections

### DIFF
--- a/docs/devs/firstmove.md
+++ b/docs/devs/firstmove.md
@@ -44,7 +44,7 @@ Due to current network load, we have restricted the faucet API to only accept re
 
    Type `custom` and press **Enter**.
 
-  You will be promted for the following details from our [Network EndPoints](/devs/networkEndpoints)
+  You will be prompted for the following details from our [Network EndPoints](/devs/networkEndpoints)
 
   - RPC/Rest Endpoint: https://aptos.testnet.porto.movementlabs.xyz/v1
   - Faucet Endpoint: https://faucet.testnet.porto.movementnetwork.xyz/

--- a/docs/devs/indexing.md
+++ b/docs/devs/indexing.md
@@ -4,7 +4,7 @@ sidebar_position: 5
 
 # Indexers
 
-The Movement Indexer is a GraphQL API you can use to retrive Aggregate data, Historical data, and Data that might be hard to get from the simpler FullNode API. 
+The Movement Indexer is a GraphQL API you can use to retrieve Aggregate data, Historical data, and Data that might be hard to get from the simpler FullNode API. 
 
 | Service          | URL                                                                    |
 |------------------|------------------------------------------------------------------------|

--- a/docs/devs/networkEndpoints.md
+++ b/docs/devs/networkEndpoints.md
@@ -99,7 +99,7 @@ Please note that the Sui Baku Devnet has been deprecated. We will share our road
 
 Here is the reformatted table with everything under "Sui Baku Devnet" removed:
 
-|  | Aptos Suzuka Testnet  | Aptos Suzuka Devnet | MEVEM Imola Devnet  |
+|  | Aptos Suzuka Testnet  | Aptos Suzuka Devnet | MEVM Imola Devnet  |
 | --- | --- | --- | --- |
 | Validators  | Movement Labs operated validators  | Permissionless + Movement Labs operated validators.  | NA |
 | Full Nodes  | Movement Labs operated nodes  | Permissionless + Movement Labs operated nodes  | Movement Labs operated nodes  |


### PR DESCRIPTION
### Typo corrections to documentation for the following files

**docs/devs/firstmove.md**

Typo in the word "promted":

Original: "You will be promted for the following details from our Network EndPoints"

Corrected: "You will be prompted for the following details from our Network EndPoints".

Corrected.

**docs/devs/indexing.md**

The word "retrive" in the first paragraph should be written as "retrieve".

Corrected.

**docs/devs/networkEndpoints.md**

The word "MEVEM" should be "MEVM" (missing "V" in the acronym).

Corrected.

### Goal

Correct grammatical errors and improve readability of the documentation.
