### PR TITLE
docs: resolve compile warnings

### DIFF
--- a/docs/devs/firstmove.md
+++ b/docs/devs/firstmove.md
@@ -179,7 +179,7 @@ Open `hello_blockchain.move` in your preferred text editor and paste the followi
 module hello_blockchain::message {
     use std::error;
     use std::signer;
-    use std::string::{String, utf8};
+    use std::string::{String};
     use aptos_framework::account;
     use aptos_framework::event;
 
@@ -229,10 +229,10 @@ module hello_blockchain::message {
     public entry fun sender_can_set_message(account: signer) acquires MessageHolder {
         let addr = signer::address_of(&account);
         aptos_framework::account::create_account_for_test(addr);
-        set_message(account, utf8(b"Hello, Blockchain"));
+        set_message(account, std::string::utf8(b"Hello, Blockchain"));
 
         assert!(
-            get_message(addr) == utf8(b"Hello, Blockchain"),
+            get_message(addr) == std::string::utf8(b"Hello, Blockchain"),
             ENO_MESSAGE
         );
     }


### PR DESCRIPTION
When following this guide https://docs.movementnetwork.xyz/devs/firstmove

I ran into unused alias warnings when compiling:

```
aptos move compile
Compiling, may take a little while to download git dependencies...
FETCHING GIT DEPENDENCY https://github.com/aptos-labs/aptos-framework.git
INCLUDING DEPENDENCY AptosFramework
INCLUDING DEPENDENCY AptosStdlib
INCLUDING DEPENDENCY MoveStdlib
BUILDING hello_blockchain
warning[W09001]: unused alias
  ┌─ /Users/js/hello-chain/sources/hello_blockchain.move:4:31
  │
4 │     use std::string::{String, utf8};
  │                               ^^^^ Unused 'use' of alias 'utf8'. Consider removing it

warning: unused alias
  ┌─ /Users/js/hello-chain/sources/hello_blockchain.move:4:31
  │
4 │     use std::string::{String, utf8};
  │                               ^^^^ Unused 'use' of alias 'utf8'. Consider removing it

{
  "Result": [
    "e69c0875d4e04984cfc02b661d2d61fd12a2835347703b0a21efefab40fd2198::message"
  ]
}
```

When testing, similar things happens:

```
aptos move test
INCLUDING DEPENDENCY AptosFramework
INCLUDING DEPENDENCY AptosStdlib
INCLUDING DEPENDENCY MoveStdlib
BUILDING hello_blockchain
warning[W09003]: unused assignment
     ┌─ /Users/js/.move/https___github_com_aptos-labs_aptos-framework_git_mainnet/aptos-framework/sources/account.move:1593:13
     │
1593 │         let eventhandle = &borrow_global<Account>(addr).coin_register_events;
     │             ^^^^^^^^^^^ Unused assignment or binding for local 'eventhandle'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_eventhandle')

warning: unused alias
  ┌─ /Users/js/hello-chain/sources/hello_blockchain.move:4:31
  │
4 │     use std::string::{String, utf8};
  │                               ^^^^ Unused 'use' of alias 'utf8'. Consider removing it

Running Move unit tests
[ PASS    ] 0xe69c0875d4e04984cfc02b661d2d61fd12a2835347703b0a21efefab40fd2198::message::sender_can_set_message
[ PASS    ] 0xe69c0875d4e04984cfc02b661d2d61fd12a2835347703b0a21efefab40fd2198::message::signature_okay
Test result: OK. Total tests: 2; passed: 2; failed: 0
{
  "Result": "Success"
}
```

After making the changes in this PR, compile is clean:

```
aptos move compile
Compiling, may take a little while to download git dependencies...
UPDATING GIT DEPENDENCY https://github.com/aptos-labs/aptos-framework.git
INCLUDING DEPENDENCY AptosFramework
INCLUDING DEPENDENCY AptosStdlib
INCLUDING DEPENDENCY MoveStdlib
BUILDING hello_blockchain
{
  "Result": [
    "e69c0875d4e04984cfc02b661d2d61fd12a2835347703b0a21efefab40fd2198::message"
  ]
}
```

And testing is clean aside from bug in aptos:

```
aptos move test
INCLUDING DEPENDENCY AptosFramework
INCLUDING DEPENDENCY AptosStdlib
INCLUDING DEPENDENCY MoveStdlib
BUILDING hello_blockchain
warning[W09003]: unused assignment
     ┌─ /Users/js/.move/https___github_com_aptos-labs_aptos-framework_git_mainnet/aptos-framework/sources/account.move:1593:13
     │
1593 │         let eventhandle = &borrow_global<Account>(addr).coin_register_events;
     │             ^^^^^^^^^^^ Unused assignment or binding for local 'eventhandle'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_eventhandle')

Running Move unit tests
[ PASS    ] 0xe69c0875d4e04984cfc02b661d2d61fd12a2835347703b0a21efefab40fd2198::message::sender_can_set_message
[ PASS    ] 0xe69c0875d4e04984cfc02b661d2d61fd12a2835347703b0a21efefab40fd2198::message::signature_okay
Test result: OK. Total tests: 2; passed: 2; failed: 0
{
  "Result": "Success"
}
```