### PR TITLE
📚 Fix Razor Kit documentation link in templates.mdx

### DIFF
--- a/docs/devs/interactonchain/wallet-adapter/templates.mdx
+++ b/docs/devs/interactonchain/wallet-adapter/templates.mdx
@@ -13,6 +13,6 @@ Below you can find a list of templates and documentations for Wallet SDKs from m
 <CustomDocCardList items={[
   {type: 'link', label: 'OKX Connect', href: 'https://www.okx.com/web3/build/docs/sdks/app-connect-aptos', description: "OKX Connect Documentation"},
   {type: 'link', label: 'Nightly Connect Template', href: 'https://movement-web3-template.nightly.app/', description: "Starter Template for Nightly Connect"},
-  {type: 'link', label: 'Razor Kit', href: 'https://kit.razorwallet.xyz/docs/quickstart', description: "Razor Kit Documentation"},
+  {type: 'link', label: 'Razor Kit', href: 'https://kit.razorwallet.xyz/docs/getting-started', description: "Razor Kit Documentation"},
 
 ]} />


### PR DESCRIPTION
This PR fixes the incorrect link for the Razor Kit documentation in the templates.mdx file.
The previous link was outdated and has been updated to the correct URL.