### PR TITLE
chore: fix link to First Move Contract page

### DIFF
--- a/docs/general/intro.mdx
+++ b/docs/general/intro.mdx
@@ -18,7 +18,7 @@ Welcome to Movement! This documentation will help you understand the Movement ec
   {type: 'link', label: 'Vision', href: '/general/Introduction', description: "Learn more about the Movement Network"},
   {type: 'link', label: 'Architecture', href: '/general/Mainnet', description: "Learn more about the Architecture"},
   {type: 'link', label: 'Developers', href: '/devs/getstarted', description: "Get started as a Developer"},
-  {type: 'link', label: 'Your First Move', href: '/devs/firstmove', description: "Build your first Move Module"},
+  {type: 'link', label: 'Your First Move', href: '/devs/firstMoveContract', description: "Build your first Move Module"},
   {type: 'link', label: 'Faucets', href: '/general/UsingMovement/faucet', description: "Get Testnet Tokens"},
   {type: 'link', label: 'Explorer', href: 'https://explorer.movementnetwork.xyz/', description: "Our Block Explorer"},
 ]} />


### PR DESCRIPTION
Fix front-page link to "Your First Move Contract" page.