### PR TITLE
docs: add NEAR Intents SDK integration guide

### DIFF
--- a/content/docs/devs/interactonchain/meta.json
+++ b/content/docs/devs/interactonchain/meta.json
@@ -1,6 +1,6 @@
 {
     "title": "Interact on Chain",
-    "pages": ["tsSdk", "rustSDK", "pythonSDK", "wallet-adapter"],
+    "pages": ["tsSdk", "rustSDK", "pythonSDK", "wallet-adapter", "near-intents-sdk"],
     "root": false,
     "defaultOpen": true
 } 

--- a/content/docs/devs/interactonchain/near-intents-sdk.mdx
+++ b/content/docs/devs/interactonchain/near-intents-sdk.mdx
@@ -1,0 +1,286 @@
+---
+title: NEAR Intents SDK
+description: Move USDC or USDT from Ethereum, Polygon, or Tron onto Movement over NEAR Intents with a small TypeScript SDK.
+---
+
+# NEAR Intents SDK
+
+The [`@moveindustries/near-intents-sdk`](https://github.com/MoveIndustries/near-intents-sdk) is a thin TypeScript SDK for moving **USDC or USDT** from a supported origin chain onto **Movement** — landing as **USDCx** or **MOVE** — over [NEAR Intents](https://docs.near-intents.org). It wraps the official [1Click API](https://docs.near-intents.org/near-intents/integration/distribution-channels/1click-api) and pins the destination to Movement, so a transfer can't accidentally land on the wrong chain.
+
+It orchestrates the transfer — get a quote, build the deposit, track status — and **never signs, broadcasts, or holds keys**. Your own wallet signs the one on-chain step.
+
+**The flow in four steps:**
+
+1. **Quote** a route (origin chain + asset → Movement asset) and receive a one-time deposit address.
+2. **Build** the unsigned deposit transaction — a plain token transfer to that address.
+3. **Sign & broadcast** it with your own wallet.
+4. **Track** execution status until it reaches a terminal state.
+
+<Callout type="info">
+
+The destination is always Movement. You choose the origin (Ethereum, Polygon, or Tron), the origin asset (USDC or USDT), and whether you receive USDCx or MOVE on Movement.
+
+</Callout>
+
+## Installation
+
+```bash tab="npm"
+npm install @moveindustries/near-intents-sdk
+```
+
+```bash tab="pnpm"
+pnpm add @moveindustries/near-intents-sdk
+```
+
+```bash tab="yarn"
+yarn add @moveindustries/near-intents-sdk
+```
+
+```bash tab="bun"
+bun add @moveindustries/near-intents-sdk
+```
+
+## Quick start
+
+This is the full end-to-end transfer of **1 USDC on Ethereum → USDCx on Movement**. It runs without any credentials.
+
+```ts
+import {
+  configure,
+  quoteDeposit,
+  prepareDepositTx,
+  submitDeposit,
+  getStatus,
+  isTerminal,
+} from "@moveindustries/near-intents-sdk";
+
+// configure() is optional — omit it entirely to run token-free (see Authentication).
+configure({ jwt: process.env.ONE_CLICK_JWT });
+
+// 1. Quote the route. Amounts are in the origin asset's smallest units.
+const res = await quoteDeposit({
+  originChain: "ethereum",     // "ethereum" | "polygon" | "tron"
+  originAsset: "usdc",         // "usdc" | "usdt"  (Tron is USDT-only)
+  destinationAsset: "usdcx",   // "usdcx" | "move"
+  amount: "1000000",           // 1.0 USDC (6 decimals)
+  recipient: "0xYourMovementAddress",
+  refundTo: "0xYourEthereumAddress",
+});
+
+const { depositAddress, amountOut, deadline } = res.quote;
+console.log(`Send to ${depositAddress}, you'll receive ~${amountOut} before ${deadline}`);
+
+// 2. Build the unsigned deposit transfer. Your wallet signs and broadcasts it.
+const depositTx = prepareDepositTx("ethereum", "usdc", res);
+
+// ...sign & broadcast `depositTx` with your wallet, get back a tx hash...
+const txHash = "0xYourDepositTxHash";
+
+// 3. (Optional) Hand 1Click the tx hash to speed up deposit detection.
+await submitDeposit(depositAddress!, txHash);
+
+// 4. Poll status until it settles.
+let status = (await getStatus(depositAddress!)).status;
+while (!isTerminal(status)) {
+  await new Promise((r) => setTimeout(r, 5000));
+  status = (await getStatus(depositAddress!)).status;
+}
+console.log("Final:", status); // "SUCCESS" | "REFUNDED" | "FAILED"
+```
+
+<Callout type="warn">
+
+Amounts are strings in the origin asset's **smallest units**, not decimals. USDC and USDT use 6 decimals, so `"1000000"` = 1.0 USDC and `"20000"` = 0.02 USDC.
+
+</Callout>
+
+## Authentication
+
+**A 1Click JWT is optional — the full transfer works without one.** Quoting, deposit-address binding, and status tracking all succeed unauthenticated.
+
+Pass a JWT for two reasons:
+
+- **Waive the protocol fee.** Without a token, NEAR auto-injects its `appFees` and takes a small cut of the swap.
+- **Attributed rate limits** instead of anonymous, IP-based ones.
+
+Obtain one at the [NEAR Intents Partners Portal](https://partners.near-intents.org) and pass it to `configure`:
+
+```ts
+configure({ jwt: process.env.ONE_CLICK_JWT });
+```
+
+The SDK never mints or refreshes tokens — it only forwards the one you give it.
+
+## Using it in the browser
+
+A JWT is a secret, so **never ship it to the client**. Instead, put a thin server-side proxy in front of the 1Click API that injects the token, and point the SDK at that proxy with `baseUrl` (omit `jwt` — the proxy holds it):
+
+```ts
+// Client code — no secret here. Requests go to your proxy, which adds the JWT.
+configure({ baseUrl: "/api/1click" });
+```
+
+A minimal proxy (Next.js Route Handler shown) forwards a small allowlist of 1Click paths and adds the `Authorization` header server-side:
+
+```ts
+// app/api/1click/[...path]/route.ts
+import { NextRequest, NextResponse } from "next/server";
+
+const BASE = process.env.ONECLICK_BASE_URL ?? "https://1click.chaindefuser.com";
+const JWT = process.env.ONECLICK_JWT; // server-side only — never NEXT_PUBLIC_
+
+// Only the paths the SDK uses may be proxied.
+const ALLOWED = new Set(["v0/tokens", "v0/quote", "v0/status", "v0/deposit/submit"]);
+
+async function forward(method: "GET" | "POST", req: NextRequest, path: string[]) {
+  const joined = path.join("/");
+  if (!ALLOWED.has(joined)) {
+    return NextResponse.json({ error: "Path not allowed" }, { status: 400 });
+  }
+  const url = new URL(`${BASE}/${joined}`);
+  req.nextUrl.searchParams.forEach((v, k) => url.searchParams.set(k, v));
+  const res = await fetch(url.toString(), {
+    method,
+    headers: {
+      ...(JWT ? { Authorization: `Bearer ${JWT}` } : {}),
+      ...(method === "POST" ? { "Content-Type": "application/json" } : {}),
+    },
+    body: method === "POST" ? await req.text() : undefined,
+  });
+  const data = await res.json().catch(() => ({}));
+  return NextResponse.json(data, { status: res.status });
+}
+
+export async function GET(req: NextRequest, { params }: { params: Promise<{ path: string[] }> }) {
+  return forward("GET", req, (await params).path);
+}
+export async function POST(req: NextRequest, { params }: { params: Promise<{ path: string[] }> }) {
+  return forward("POST", req, (await params).path);
+}
+```
+
+<Callout type="info">
+
+Without `baseUrl`, the SDK calls the 1Click API directly — fine for server-side scripts and backends where the JWT stays private.
+
+</Callout>
+
+## Signing the deposit transaction
+
+`prepareDepositTx` returns an **unsigned** transfer of the quote's `amountIn` to its `depositAddress`. The shape depends on the origin chain family — EVM (Ethereum, Polygon) or Tron:
+
+```ts
+const depositTx = prepareDepositTx("ethereum", "usdc", res);
+
+// EVM  → { family: "evm",  to, value: "0x0", data }
+// Tron → { family: "tron", contractAddress, function: "transfer(address,uint256)", parameter }
+```
+
+### EVM (Ethereum / Polygon)
+
+The deposit is a standard ERC-20 `transfer`. With [viem](https://viem.sh):
+
+```ts
+import { erc20Abi } from "viem";
+
+const { depositAddress, amountIn } = res.quote;
+
+const hash = await walletClient.writeContract({
+  address: tokenAddress as `0x${string}`, // the origin USDC/USDT contract
+  abi: erc20Abi,
+  functionName: "transfer",
+  args: [depositAddress as `0x${string}`, BigInt(amountIn)],
+  account: walletClient.account!,
+  chain: walletClient.chain,
+});
+```
+
+### Tron
+
+The deposit is a TRC-20 `transfer` via the injected TronLink provider:
+
+```ts
+const { depositAddress, amountIn } = res.quote;
+
+const contract = await tronWeb.contract().at(tokenAddress); // TRC-20 USDT
+const txId = await contract.transfer(depositAddress, amountIn).send();
+```
+
+<Callout type="warn">
+
+The origin wallet needs the chain's **native gas token** to send the deposit (ETH on Ethereum, POL on Polygon, TRX on Tron) — the SDK moves the stablecoin, not gas.
+
+</Callout>
+
+## Tracking status
+
+Call `getStatus` on your own cadence until `isTerminal` returns `true`:
+
+```ts
+async function waitForSettlement(depositAddress: string) {
+  for (;;) {
+    const { status } = await getStatus(depositAddress);
+    if (isTerminal(status)) return status; // SUCCESS | REFUNDED | FAILED
+    await new Promise((r) => setTimeout(r, 5000));
+  }
+}
+```
+
+Non-terminal statuses (`PENDING_DEPOSIT`, `KNOWN_DEPOSIT_TX`, `INCOMPLETE_DEPOSIT`, `PROCESSING`) all mean the transfer is still in flight.
+
+## Listing supported tokens
+
+`listTokens` returns the live set of supported tokens, filtered to the SDK's routes and tagged with the route keys `quoteDeposit` expects — so you can feed a token straight into a quote without any lookup:
+
+```ts
+import { listTokens } from "@moveindustries/near-intents-sdk";
+
+const tokens = await listTokens();
+// each token carries: assetId, symbol, decimals, chain, contractAddress, price,
+// and its route keys — originChain, originAsset (sources) or destinationAsset (Movement)
+```
+
+## Supported routes
+
+| Origin chain | Assets           | Movement destination |
+| ------------ | ---------------- | -------------------- |
+| Ethereum     | USDC, USDT       | USDCx or MOVE        |
+| Polygon      | USDC, USDT       | USDCx or MOVE        |
+| Tron         | USDT             | USDCx or MOVE        |
+
+<Callout type="info">
+
+When your destination is **MOVE**, raise `slippageTolerance` — MOVE is volatile, and the default 1% is often missed, causing a refund instead of a completed swap. `300` (3%) is a reasonable starting point. For the ~1:1 USDCx route, the default is fine.
+
+</Callout>
+
+## API reference
+
+| Function                                        | Purpose                                                                                     |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `configure({ jwt?, baseUrl? })`                 | Optional. Set a 1Click JWT and/or point the SDK at a server-side proxy.                     |
+| `quoteDeposit(params)`                          | Quote a route; returns the quote with `depositAddress`, `amountIn`, `amountOut`, `deadline`. |
+| `prepareDepositTx(origin, originAsset, quote)`  | Build the **unsigned** deposit transfer for your wallet to sign.                            |
+| `submitDeposit(depositAddress, txHash)`         | Optional. Hand 1Click the deposit tx hash to speed up detection.                            |
+| `getStatus(depositAddress)`                     | Read the transfer's current execution status once.                                          |
+| `isTerminal(status)`                            | `true` for `SUCCESS`, `REFUNDED`, or `FAILED`.                                              |
+| `listTokens()`                                  | Live, route-tagged list of supported tokens.                                                |
+
+### `quoteDeposit` parameters
+
+| Field                | Type                                   | Notes                                                     |
+| -------------------- | -------------------------------------- | --------------------------------------------------------- |
+| `originChain`        | `"ethereum" \| "polygon" \| "tron"`    | Source chain.                                             |
+| `originAsset`        | `"usdc" \| "usdt"`                     | Source asset. Tron is USDT-only.                          |
+| `destinationAsset`   | `"usdcx" \| "move"`                    | What you receive on Movement.                             |
+| `amount`             | `string`                               | Smallest units of the origin asset (USDC/USDT: 6 dp).     |
+| `recipient`          | `string`                               | Your Movement address.                                    |
+| `refundTo`           | `string`                               | Origin-chain address to refund if the swap can't settle.  |
+| `slippageTolerance?` | `number`                               | Basis points. Defaults to `100` (1%). Raise it for MOVE.  |
+| `deadline?`          | `string`                               | ISO timestamp. Defaults to 10 minutes from now.           |
+
+## Learn more
+
+- [SDK repository & README](https://github.com/MoveIndustries/near-intents-sdk)
+- [NEAR Intents documentation](https://docs.near-intents.org)
+- [1Click API reference](https://docs.near-intents.org/near-intents/integration/distribution-channels/1click-api)

--- a/content/docs/devs/interactonchain/near-intents-sdk.mdx
+++ b/content/docs/devs/interactonchain/near-intents-sdk.mdx
@@ -12,7 +12,7 @@ It orchestrates the transfer — get a quote, build the deposit, track status �
 **The flow in four steps:**
 
 1. **Quote** a route (origin chain + asset → Movement asset) and receive a one-time deposit address.
-2. **Build** the unsigned deposit transaction — a plain token transfer to that address.
+2. **Build** the unsigned deposit transaction with `prepareDepositTx` — a plain token transfer to that address.
 3. **Sign & broadcast** it with your own wallet.
 4. **Track** execution status until it reaches a terminal state.
 
@@ -42,7 +42,7 @@ bun add @moveindustries/near-intents-sdk
 
 ## Quick start
 
-This is the full end-to-end transfer of **1 USDC on Ethereum → USDCx on Movement**. It runs without any credentials.
+The full end-to-end transfer of **1 USDC on Ethereum → USDCx on Movement**. It runs without any credentials.
 
 ```ts
 import {
@@ -73,7 +73,7 @@ console.log(`Send to ${depositAddress}, you'll receive ~${amountOut} before ${de
 // 2. Build the unsigned deposit transfer. Your wallet signs and broadcasts it.
 const depositTx = prepareDepositTx("ethereum", "usdc", res);
 
-// ...sign & broadcast `depositTx` with your wallet, get back a tx hash...
+// ...sign & broadcast `depositTx` with your wallet (see per-chain examples below)...
 const txHash = "0xYourDepositTxHash";
 
 // 3. (Optional) Hand 1Click the tx hash to speed up deposit detection.
@@ -109,11 +109,11 @@ Obtain one at the [NEAR Intents Partners Portal](https://partners.near-intents.o
 configure({ jwt: process.env.ONE_CLICK_JWT });
 ```
 
-The SDK never mints or refreshes tokens — it only forwards the one you give it.
+You own the token. The SDK just attaches whatever JWT you pass to its requests — it doesn't create one for you, and it won't renew it when it expires. Getting a token from the Partners Portal and swapping in a fresh one before the old one lapses is on you.
 
 ## Using it in the browser
 
-A JWT is a secret, so **never ship it to the client**. Instead, put a thin server-side proxy in front of the 1Click API that injects the token, and point the SDK at that proxy with `baseUrl` (omit `jwt` — the proxy holds it):
+A JWT is a secret, so **never ship it to the client**. Put a thin server-side proxy in front of the 1Click API that injects the token, and point the SDK at that proxy with `baseUrl` (omit `jwt` — the proxy holds it):
 
 ```ts
 // Client code — no secret here. Requests go to your proxy, which adds the JWT.
@@ -165,46 +165,19 @@ Without `baseUrl`, the SDK calls the 1Click API directly — fine for server-sid
 
 </Callout>
 
-## Signing the deposit transaction
+## The deposit transaction
 
-`prepareDepositTx` returns an **unsigned** transfer of the quote's `amountIn` to its `depositAddress`. The shape depends on the origin chain family — EVM (Ethereum, Polygon) or Tron:
-
-```ts
-const depositTx = prepareDepositTx("ethereum", "usdc", res);
-
-// EVM  → { family: "evm",  to, value: "0x0", data }
-// Tron → { family: "tron", contractAddress, function: "transfer(address,uint256)", parameter }
-```
-
-### EVM (Ethereum / Polygon)
-
-The deposit is a standard ERC-20 `transfer`. With [viem](https://viem.sh):
+`prepareDepositTx(originChain, originAsset, quote)` returns an **unsigned** transfer of the quote's `amountIn` to its `depositAddress`. The shape depends on the origin chain family:
 
 ```ts
-import { erc20Abi } from "viem";
+// EVM (Ethereum, Polygon)
+{ family: "evm", to: string, value: "0x0", data: string }
 
-const { depositAddress, amountIn } = res.quote;
-
-const hash = await walletClient.writeContract({
-  address: tokenAddress as `0x${string}`, // the origin USDC/USDT contract
-  abi: erc20Abi,
-  functionName: "transfer",
-  args: [depositAddress as `0x${string}`, BigInt(amountIn)],
-  account: walletClient.account!,
-  chain: walletClient.chain,
-});
+// Tron
+{ family: "tron", contractAddress: string, function: "transfer(address,uint256)", parameter: [depositAddress, amountIn] }
 ```
 
-### Tron
-
-The deposit is a TRC-20 `transfer` via the injected TronLink provider:
-
-```ts
-const { depositAddress, amountIn } = res.quote;
-
-const contract = await tronWeb.contract().at(tokenAddress); // TRC-20 USDT
-const txId = await contract.transfer(depositAddress, amountIn).send();
-```
+The SDK already knows each chain's USDC/USDT contract, so you don't pass a token address — everything needed to sign is in the returned object. The per-chain examples below show how to hand it to a wallet.
 
 <Callout type="warn">
 
@@ -212,11 +185,13 @@ The origin wallet needs the chain's **native gas token** to send the deposit (ET
 
 </Callout>
 
-## Tracking status
+## Complete examples
 
-Call `getStatus` on your own cadence until `isTerminal` returns `true`:
+Each example runs the full flow for one route. They share the `waitForSettlement` helper:
 
 ```ts
+import { getStatus, isTerminal } from "@moveindustries/near-intents-sdk";
+
 async function waitForSettlement(depositAddress: string) {
   for (;;) {
     const { status } = await getStatus(depositAddress);
@@ -226,7 +201,173 @@ async function waitForSettlement(depositAddress: string) {
 }
 ```
 
-Non-terminal statuses (`PENDING_DEPOSIT`, `KNOWN_DEPOSIT_TX`, `INCOMPLETE_DEPOSIT`, `PROCESSING`) all mean the transfer is still in flight.
+### Ethereum → USDCx (server-side, viem)
+
+A backend script that signs with a private key and calls 1Click directly (JWT stays server-side, no proxy needed). The EVM deposit is a raw transaction built entirely from `prepareDepositTx`.
+
+```ts
+import { createWalletClient, http } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { mainnet } from "viem/chains";
+import { configure, quoteDeposit, prepareDepositTx, submitDeposit } from "@moveindustries/near-intents-sdk";
+
+configure({ jwt: process.env.ONE_CLICK_JWT }); // optional
+
+const account = privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`);
+const wallet = createWalletClient({ account, chain: mainnet, transport: http() });
+
+const res = await quoteDeposit({
+  originChain: "ethereum",
+  originAsset: "usdc",
+  destinationAsset: "usdcx",
+  amount: "1000000", // 1.0 USDC
+  recipient: "0xYourMovementAddress",
+  refundTo: account.address,
+});
+const { depositAddress } = res.quote;
+
+// prepareDepositTx returns { family: "evm", to, value: "0x0", data } — send it as-is.
+const tx = prepareDepositTx("ethereum", "usdc", res);
+const txHash = await wallet.sendTransaction({
+  account,
+  chain: mainnet,
+  to: tx.to as `0x${string}`,
+  value: 0n,
+  data: tx.data as `0x${string}`,
+});
+
+await submitDeposit(depositAddress!, txHash); // optional speed-up
+console.log("Settled:", await waitForSettlement(depositAddress!));
+```
+
+### Polygon → MOVE (browser wallet, viem)
+
+A browser flow using an injected wallet (e.g. via wagmi's `useWalletClient`). Because the destination is **MOVE** (volatile), slippage is raised so the swap doesn't refund.
+
+```ts
+import { useWalletClient } from "wagmi";
+import { configure, quoteDeposit, prepareDepositTx, submitDeposit } from "@moveindustries/near-intents-sdk";
+
+configure({ baseUrl: "/api/1click" }); // browser → proxy holds the JWT
+
+async function bridgePolygonToMove(wallet: NonNullable<ReturnType<typeof useWalletClient>["data"]>) {
+  const res = await quoteDeposit({
+    originChain: "polygon",
+    originAsset: "usdc",
+    destinationAsset: "move",
+    amount: "5000000",        // 5.0 USDC
+    recipient: "0xYourMovementAddress",
+    refundTo: wallet.account.address,
+    slippageTolerance: 300,   // 3% — MOVE is volatile; the 1% default often refunds
+  });
+  const { depositAddress } = res.quote;
+
+  const tx = prepareDepositTx("polygon", "usdc", res);
+  const txHash = await wallet.sendTransaction({
+    to: tx.to as `0x${string}`,
+    value: 0n,
+    data: tx.data as `0x${string}`,
+  });
+
+  await submitDeposit(depositAddress!, txHash);
+  return waitForSettlement(depositAddress!);
+}
+```
+
+### Tron → USDCx (injected TronLink)
+
+Tron is USDT-only. The deposit is a TRC-20 transfer through the injected `window.tronWeb` provider (TronLink):
+
+```ts
+import { configure, quoteDeposit, prepareDepositTx, submitDeposit } from "@moveindustries/near-intents-sdk";
+
+configure({ baseUrl: "/api/1click" });
+
+async function bridgeTronToUsdcx(recipient: string, refundTo: string) {
+  const tronWeb = (window as any).tronWeb;
+  if (!tronWeb?.defaultAddress?.base58) throw new Error("Connect TronLink");
+
+  const res = await quoteDeposit({
+    originChain: "tron",
+    originAsset: "usdt",
+    destinationAsset: "usdcx",
+    amount: "1000000", // 1.0 USDT
+    recipient,
+    refundTo, // your Tron address, for refunds
+  });
+  const { depositAddress } = res.quote;
+
+  // prepareDepositTx returns { family: "tron", contractAddress, function, parameter: [to, amount] }
+  const tx = prepareDepositTx("tron", "usdt", res);
+  const contract = await tronWeb.contract().at(tx.contractAddress);
+  const txId: string = await contract.transfer(tx.parameter[0], tx.parameter[1]).send();
+
+  await submitDeposit(depositAddress!, txId);
+  return waitForSettlement(depositAddress!);
+}
+```
+
+### Tron → USDCx (TronWallet Adapter)
+
+If you'd rather not touch `window.tronWeb` directly, use the [TronWallet Adapter](https://github.com/tronprotocol/tronwallet-adapter) React hooks. You build the transaction with a standalone `TronWeb` instance, sign it with the adapter's `signTransaction`, then broadcast. This maps cleanly onto `prepareDepositTx`'s Tron output.
+
+```ts
+import { TronWeb } from "tronweb";
+import { useWallet } from "@tronweb3/tronwallet-adapter-react-hooks";
+import { configure, quoteDeposit, prepareDepositTx, submitDeposit } from "@moveindustries/near-intents-sdk";
+
+configure({ baseUrl: "/api/1click" });
+
+// A read-only client just for building + broadcasting; the adapter does the signing.
+const tronWeb = new TronWeb({ fullHost: "https://api.trongrid.io" });
+
+function BridgeButton({ recipient }: { recipient: string }) {
+  const { address, signTransaction, connected } = useWallet();
+
+  async function bridge() {
+    if (!connected || !address) throw new Error("Connect a Tron wallet");
+
+    const res = await quoteDeposit({
+      originChain: "tron",
+      originAsset: "usdt",
+      destinationAsset: "usdcx",
+      amount: "1000000", // 1.0 USDT
+      recipient,
+      refundTo: address,
+    });
+    const { depositAddress } = res.quote;
+
+    const tx = prepareDepositTx("tron", "usdt", res);
+
+    // Build the TRC-20 transfer from prepareDepositTx's contract + params.
+    const { transaction } = await tronWeb.transactionBuilder.triggerSmartContract(
+      tx.contractAddress,
+      tx.function, // "transfer(address,uint256)"
+      {},
+      [
+        { type: "address", value: tx.parameter[0] }, // deposit address
+        { type: "uint256", value: tx.parameter[1] }, // amountIn
+      ],
+      address,
+    );
+
+    const signed = await signTransaction(transaction);
+    const receipt = await tronWeb.trx.sendRawTransaction(signed);
+    const txId: string = receipt.txid;
+
+    await submitDeposit(depositAddress!, txId);
+    return waitForSettlement(depositAddress!);
+  }
+
+  return <button onClick={bridge}>Bridge USDT → USDCx</button>;
+}
+```
+
+<Callout type="info">
+
+The adapter needs its provider set up once near the root of your app — wrap it in `WalletProvider` from `@tronweb3/tronwallet-adapter-react-hooks` (and optionally `WalletModalProvider` from `@tronweb3/tronwallet-adapter-react-ui`). See the [adapter docs](https://developers.tron.network/docs/tronwallet-adapter) for setup.
+
+</Callout>
 
 ## Listing supported tokens
 
@@ -240,13 +381,30 @@ const tokens = await listTokens();
 // and its route keys — originChain, originAsset (sources) or destinationAsset (Movement)
 ```
 
+## Dry-run quotes
+
+Pass `dry: true` to `quoteDeposit` to price a route without reserving a deposit address — useful for showing an estimate before the user commits. A dry quote has no `depositAddress`, so don't pass it to `prepareDepositTx`.
+
+```ts
+const preview = await quoteDeposit({
+  originChain: "ethereum",
+  originAsset: "usdc",
+  destinationAsset: "usdcx",
+  amount: "1000000",
+  recipient: "0xYourMovementAddress",
+  refundTo: "0xYourEthereumAddress",
+  dry: true,
+});
+console.log("You'd receive ~", preview.quote.amountOutFormatted ?? preview.quote.amountOut);
+```
+
 ## Supported routes
 
-| Origin chain | Assets           | Movement destination |
-| ------------ | ---------------- | -------------------- |
-| Ethereum     | USDC, USDT       | USDCx or MOVE        |
-| Polygon      | USDC, USDT       | USDCx or MOVE        |
-| Tron         | USDT             | USDCx or MOVE        |
+| Origin chain | Assets     | Movement destination |
+| ------------ | ---------- | -------------------- |
+| Ethereum     | USDC, USDT | USDCx or MOVE        |
+| Polygon      | USDC, USDT | USDCx or MOVE        |
+| Tron         | USDT       | USDCx or MOVE        |
 
 <Callout type="info">
 
@@ -256,28 +414,32 @@ When your destination is **MOVE**, raise `slippageTolerance` — MOVE is volatil
 
 ## API reference
 
-| Function                                        | Purpose                                                                                     |
+| Export                                          | Purpose                                                                                     |
 | ----------------------------------------------- | ------------------------------------------------------------------------------------------- |
 | `configure({ jwt?, baseUrl? })`                 | Optional. Set a 1Click JWT and/or point the SDK at a server-side proxy.                     |
 | `quoteDeposit(params)`                          | Quote a route; returns the quote with `depositAddress`, `amountIn`, `amountOut`, `deadline`. |
-| `prepareDepositTx(origin, originAsset, quote)`  | Build the **unsigned** deposit transfer for your wallet to sign.                            |
+| `prepareDepositTx(origin, originAsset, quote)`  | Build the **unsigned** deposit transfer (`EvmDepositTx` or `TronDepositTx`) for your wallet. |
 | `submitDeposit(depositAddress, txHash)`         | Optional. Hand 1Click the deposit tx hash to speed up detection.                            |
 | `getStatus(depositAddress)`                     | Read the transfer's current execution status once.                                          |
 | `isTerminal(status)`                            | `true` for `SUCCESS`, `REFUNDED`, or `FAILED`.                                              |
-| `listTokens()`                                  | Live, route-tagged list of supported tokens.                                                |
+| `listTokens()`                                  | Live, route-tagged list of supported tokens (`SupportedToken[]`).                           |
+| `MOVEMENT`, `ORIGINS`                            | Registry objects: destination and origin assets with their `assetId` / `decimals`.          |
+
+**Exported types:** `QuoteDepositParams`, `DepositTx`, `EvmDepositTx`, `TronDepositTx`, `SupportedToken`, `OriginKey`, `StableKey`, `DestKey`.
 
 ### `quoteDeposit` parameters
 
-| Field                | Type                                   | Notes                                                     |
-| -------------------- | -------------------------------------- | --------------------------------------------------------- |
-| `originChain`        | `"ethereum" \| "polygon" \| "tron"`    | Source chain.                                             |
-| `originAsset`        | `"usdc" \| "usdt"`                     | Source asset. Tron is USDT-only.                          |
-| `destinationAsset`   | `"usdcx" \| "move"`                    | What you receive on Movement.                             |
-| `amount`             | `string`                               | Smallest units of the origin asset (USDC/USDT: 6 dp).     |
-| `recipient`          | `string`                               | Your Movement address.                                    |
-| `refundTo`           | `string`                               | Origin-chain address to refund if the swap can't settle.  |
-| `slippageTolerance?` | `number`                               | Basis points. Defaults to `100` (1%). Raise it for MOVE.  |
-| `deadline?`          | `string`                               | ISO timestamp. Defaults to 10 minutes from now.           |
+| Field                | Type                                | Notes                                                     |
+| -------------------- | ----------------------------------- | --------------------------------------------------------- |
+| `originChain`        | `"ethereum" \| "polygon" \| "tron"` | Source chain.                                             |
+| `originAsset`        | `"usdc" \| "usdt"`                  | Source asset. Tron is USDT-only.                          |
+| `destinationAsset`   | `"usdcx" \| "move"`                 | What you receive on Movement.                             |
+| `amount`             | `string`                            | Smallest units of the origin asset (USDC/USDT: 6 dp).     |
+| `recipient`          | `string`                            | Your Movement address.                                    |
+| `refundTo`           | `string`                            | Origin-chain address to refund if the swap can't settle.  |
+| `slippageTolerance?` | `number`                            | Basis points. Defaults to `100` (1%). Raise it for MOVE.  |
+| `deadline?`          | `string`                            | ISO timestamp. Defaults to 10 minutes from now.           |
+| `dry?`               | `boolean`                           | Price-only preview; no deposit address is reserved.       |
 
 ## Learn more
 

--- a/content/docs/devs/interactonchain/near-intents-sdk.mdx
+++ b/content/docs/devs/interactonchain/near-intents-sdk.mdx
@@ -114,14 +114,19 @@ You own the token. The SDK just attaches whatever JWT you pass to its requests �
 
 ## Using it in the browser
 
-A JWT is a secret, so **never ship it to the client**. Put a thin server-side proxy in front of the 1Click API that injects the token, and point the SDK at that proxy with `baseUrl` (omit `jwt` — the proxy holds it):
+The SDK runs fine in the browser as-is — with no JWT it calls 1Click directly, and everything except the fee waiver still works. You only need a proxy if you want the JWT benefits (fee waiver, attributed rate limits) **and** you're running client-side, because a JWT is a secret and must **never** ship to the client.
+
+If that's you, stand up a thin server-side proxy that injects the token and point the SDK at it with `baseUrl` (omit `jwt` — the proxy holds it):
 
 ```ts
 // Client code — no secret here. Requests go to your proxy, which adds the JWT.
 configure({ baseUrl: "/api/1click" });
 ```
 
-A minimal proxy (Next.js Route Handler shown) forwards a small allowlist of 1Click paths and adds the `Authorization` header server-side:
+The proxy forwards the four paths the SDK uses (`v0/tokens`, `v0/quote`, `v0/status`, `v0/deposit/submit`) and adds the `Authorization` header server-side. A minimal Next.js Route Handler:
+
+<details>
+<summary>Example proxy — Next.js Route Handler</summary>
 
 ```ts
 // app/api/1click/[...path]/route.ts
@@ -160,9 +165,11 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ pat
 }
 ```
 
+</details>
+
 <Callout type="info">
 
-Without `baseUrl`, the SDK calls the 1Click API directly — fine for server-side scripts and backends where the JWT stays private.
+Server-side scripts and backends don't need any of this — with no `baseUrl`, the SDK calls 1Click directly and the JWT stays private.
 
 </Callout>
 

--- a/content/docs/devs/interactonchain/near-intents-sdk.mdx
+++ b/content/docs/devs/interactonchain/near-intents-sdk.mdx
@@ -9,6 +9,12 @@ The [`@moveindustries/near-intents-sdk`](https://github.com/MoveIndustries/near-
 
 It orchestrates the transfer — get a quote, build the deposit, track status — and **never signs, broadcasts, or holds keys**. Your own wallet signs the one on-chain step.
 
+<Callout>
+
+Just want to move funds yourself without writing code? Use the [NEAR Intents app](https://near.com) instead — see [NEAR Intents](/general/usingmovement/near-intents) for the no-code onboarding flow.
+
+</Callout>
+
 **The flow in four steps:**
 
 1. **Quote** a route (origin chain + asset → Movement asset) and receive a one-time deposit address.

--- a/content/docs/devs/interactonchain/near-intents-sdk.mdx
+++ b/content/docs/devs/interactonchain/near-intents-sdk.mdx
@@ -110,13 +110,13 @@ Obtain one at the [NEAR Intents Partners Portal](https://partners.near-intents.o
 configure({ jwt: process.env.ONE_CLICK_JWT });
 ```
 
-You own the token. The SDK just attaches whatever JWT you pass to its requests — it doesn't create one for you, and it won't renew it when it expires. Getting a token from the Partners Portal and swapping in a fresh one before the old one lapses is on you.
+The token is yours to manage. The SDK attaches the JWT you provide to its requests; it does not create or renew them. Obtain a token from the Partners Portal and replace it before it expires.
 
 ## Using it in the browser
 
-The SDK runs fine in the browser as-is — with no JWT it calls 1Click directly, and everything except the fee waiver still works. You only need a proxy if you want the JWT benefits (fee waiver, attributed rate limits) **and** you're running client-side, because a JWT is a secret and must **never** ship to the client.
+The SDK works in the browser without additional setup: with no JWT it calls 1Click directly, and every step except the fee waiver functions normally. A proxy is required only when combining JWT benefits (fee waiver, attributed rate limits) with client-side use, since a JWT is a secret and must **never** be exposed to the client.
 
-If that's you, stand up a thin server-side proxy that injects the token and point the SDK at it with `baseUrl` (omit `jwt` — the proxy holds it):
+To use a JWT from the browser, place a server-side proxy in front of 1Click to inject the token, and point the SDK at it with `baseUrl` (omit `jwt`; the proxy holds it):
 
 ```ts
 // Client code — no secret here. Requests go to your proxy, which adds the JWT.
@@ -169,7 +169,7 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ pat
 
 <Callout type="info">
 
-Server-side scripts and backends don't need any of this — with no `baseUrl`, the SDK calls 1Click directly and the JWT stays private.
+Server-side scripts and backends require no proxy — with no `baseUrl`, the SDK calls 1Click directly and the JWT stays private.
 
 </Callout>
 
@@ -288,7 +288,7 @@ async function bridgeTronToUsdcx(recipient: string, refundTo: string) {
 
 ### Tron → USDCx (TronWallet Adapter)
 
-If you'd rather not touch `window.tronWeb` directly, use the [TronWallet Adapter](https://github.com/tronprotocol/tronwallet-adapter) React hooks. You build the transaction with a standalone `TronWeb` instance, sign it with the adapter's `signTransaction`, then broadcast. This maps cleanly onto `prepareDepositTx`'s Tron output.
+To avoid using `window.tronWeb` directly, use the [TronWallet Adapter](https://github.com/tronprotocol/tronwallet-adapter) React hooks. You build the transaction with a standalone `TronWeb` instance, sign it with the adapter's `signTransaction`, then broadcast. This maps cleanly onto `prepareDepositTx`'s Tron output.
 
 ```ts
 import { TronWeb } from "tronweb";

--- a/content/docs/devs/interactonchain/near-intents-sdk.mdx
+++ b/content/docs/devs/interactonchain/near-intents-sdk.mdx
@@ -65,6 +65,7 @@ const res = await quoteDeposit({
   amount: "1000000",           // 1.0 USDC (6 decimals)
   recipient: "0xYourMovementAddress",
   refundTo: "0xYourEthereumAddress",
+  minAmountOut: "995000",      // required floor, destination asset's smallest units; "0" opts out
 });
 
 const { depositAddress, amountOut, deadline } = res.quote;
@@ -201,33 +202,37 @@ async function waitForSettlement(depositAddress: string) {
 }
 ```
 
-### Ethereum → USDCx (server-side, viem)
+### EVM (Ethereum or Polygon, viem)
 
-A backend script that signs with a private key and calls 1Click directly (JWT stays server-side, no proxy needed). The EVM deposit is a raw transaction built entirely from `prepareDepositTx`.
+One flow covers both EVM origins — only `originChain` and the viem `chain` differ. Shown server-side with a private key (JWT stays server-side, no proxy needed); the inline notes mark what changes in the browser and when the destination is MOVE. The EVM deposit is a raw transaction built entirely from `prepareDepositTx`.
 
 ```ts
 import { createWalletClient, http } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
-import { mainnet } from "viem/chains";
+import { mainnet } from "viem/chains"; // Polygon: import { polygon }
 import { configure, quoteDeposit, prepareDepositTx, submitDeposit } from "@moveindustries/near-intents-sdk";
 
+// Server-side, JWT stays private:
 configure({ jwt: process.env.ONE_CLICK_JWT }); // optional
+// In the browser instead: configure({ baseUrl: "/api/1click" }) — the proxy holds the JWT.
 
 const account = privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`);
 const wallet = createWalletClient({ account, chain: mainnet, transport: http() });
 
 const res = await quoteDeposit({
-  originChain: "ethereum",
+  originChain: "ethereum",   // or "polygon"
   originAsset: "usdc",
-  destinationAsset: "usdcx",
-  amount: "1000000", // 1.0 USDC
+  destinationAsset: "usdcx", // for "move", also raise slippageTolerance below
+  amount: "1000000",         // 1.0 USDC
   recipient: "0xYourMovementAddress",
   refundTo: account.address,
+  minAmountOut: "995000",    // required floor, destination asset's smallest units; "0" opts out
+  // slippageTolerance: 300, // MOVE only: 3% — MOVE is volatile; the 1% default often refunds
 });
 const { depositAddress } = res.quote;
 
 // prepareDepositTx returns { family: "evm", to, value: "0x0", data } — send it as-is.
-const tx = prepareDepositTx("ethereum", "usdc", res);
+const tx = prepareDepositTx("ethereum", "usdc", res); // match originChain above
 const txHash = await wallet.sendTransaction({
   account,
   chain: mainnet,
@@ -238,40 +243,6 @@ const txHash = await wallet.sendTransaction({
 
 await submitDeposit(depositAddress!, txHash); // optional speed-up
 console.log("Settled:", await waitForSettlement(depositAddress!));
-```
-
-### Polygon → MOVE (browser wallet, viem)
-
-A browser flow using an injected wallet (e.g. via wagmi's `useWalletClient`). Because the destination is **MOVE** (volatile), slippage is raised so the swap doesn't refund.
-
-```ts
-import { useWalletClient } from "wagmi";
-import { configure, quoteDeposit, prepareDepositTx, submitDeposit } from "@moveindustries/near-intents-sdk";
-
-configure({ baseUrl: "/api/1click" }); // browser → proxy holds the JWT
-
-async function bridgePolygonToMove(wallet: NonNullable<ReturnType<typeof useWalletClient>["data"]>) {
-  const res = await quoteDeposit({
-    originChain: "polygon",
-    originAsset: "usdc",
-    destinationAsset: "move",
-    amount: "5000000",        // 5.0 USDC
-    recipient: "0xYourMovementAddress",
-    refundTo: wallet.account.address,
-    slippageTolerance: 300,   // 3% — MOVE is volatile; the 1% default often refunds
-  });
-  const { depositAddress } = res.quote;
-
-  const tx = prepareDepositTx("polygon", "usdc", res);
-  const txHash = await wallet.sendTransaction({
-    to: tx.to as `0x${string}`,
-    value: 0n,
-    data: tx.data as `0x${string}`,
-  });
-
-  await submitDeposit(depositAddress!, txHash);
-  return waitForSettlement(depositAddress!);
-}
 ```
 
 ### Tron → USDCx (injected TronLink)
@@ -294,6 +265,7 @@ async function bridgeTronToUsdcx(recipient: string, refundTo: string) {
     amount: "1000000", // 1.0 USDT
     recipient,
     refundTo, // your Tron address, for refunds
+    minAmountOut: "995000", // required floor, destination asset's smallest units; "0" opts out
   });
   const { depositAddress } = res.quote;
 
@@ -334,6 +306,7 @@ function BridgeButton({ recipient }: { recipient: string }) {
       amount: "1000000", // 1.0 USDT
       recipient,
       refundTo: address,
+      minAmountOut: "995000", // required floor, destination asset's smallest units; "0" opts out
     });
     const { depositAddress } = res.quote;
 
@@ -393,6 +366,7 @@ const preview = await quoteDeposit({
   amount: "1000000",
   recipient: "0xYourMovementAddress",
   refundTo: "0xYourEthereumAddress",
+  minAmountOut: "0", // required; "0" opts out — fine for a price-only preview
   dry: true,
 });
 console.log("You'd receive ~", preview.quote.amountOutFormatted ?? preview.quote.amountOut);
@@ -437,6 +411,7 @@ When your destination is **MOVE**, raise `slippageTolerance` — MOVE is volatil
 | `amount`             | `string`                            | Smallest units of the origin asset (USDC/USDT: 6 dp).     |
 | `recipient`          | `string`                            | Your Movement address.                                    |
 | `refundTo`           | `string`                            | Origin-chain address to refund if the swap can't settle.  |
+| `minAmountOut`       | `string`                            | Floor in the destination asset's smallest units; the quote is rejected below it. `"0"` opts out. |
 | `slippageTolerance?` | `number`                            | Basis points. Defaults to `100` (1%). Raise it for MOVE.  |
 | `deadline?`          | `string`                            | ISO timestamp. Defaults to 10 minutes from now.           |
 | `dry?`               | `boolean`                           | Price-only preview; no deposit address is reserved.       |

--- a/content/docs/general/usingmovement/near-intents.mdx
+++ b/content/docs/general/usingmovement/near-intents.mdx
@@ -27,6 +27,10 @@ You perform the swap in the [NEAR Intents app](https://near.com). It is powered 
 3. **Deposit.** Send your USDT to the provided deposit address. The swap begins automatically once the deposit transaction is detected and confirmed on the origin chain.
 4. **Receive.** USDC.x is delivered to your Movement address.
 
+## For developers
+
+Building an integration instead of moving funds by hand? The [NEAR Intents SDK](/devs/interactonchain/near-intents-sdk) is a TypeScript SDK that runs this same USDT/USDC → Movement flow programmatically — quote a route, build the deposit, and track it to settlement.
+
 ## Learn more
 
 - [NEAR Intents overview](https://docs.near-intents.org/)


### PR DESCRIPTION
## What

Adds a developer guide for **`@moveindustries/near-intents-sdk`** — the TypeScript SDK for moving USDC/USDT from Ethereum, Polygon, or Tron onto Movement (as USDCx or MOVE) over NEAR Intents.

New page lives at **Build → Interact on Chain → NEAR Intents SDK**, alongside the other published SDKs (TS, Rust, Python, wallet-adapter).

## Contents

- Overview and the four-step transfer flow
- Installation (npm/pnpm/yarn/bun), written as already published to npm
- Token-free quick start (full end-to-end quote → deposit → track)
- Optional 1Click JWT (why you'd use one; waives the protocol fee)
- Browser usage via a server-side proxy so the JWT never ships to the client, with a minimal Next.js route-handler example
- Signing the deposit tx for EVM (viem) and Tron (TronLink)
- Status polling with `getStatus` / `isTerminal`
- Supported routes table + slippage guidance for the MOVE destination
- API reference and `quoteDeposit` parameter tables

Examples follow the SDK's authoritative README/source API (`ethereum`/`polygon`/`tron`, `getStatus`/`isTerminal`).