### PR TITLE
fix(config): add baseline security headers

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,9 +3,39 @@ import { createMDX } from 'fumadocs-mdx/next';
 const withMDX = createMDX();
 const isStatic = process.env.STATIC_EXPORT === 'true';
 
+// Baseline security headers. No HSTS here — the platform already sends it, and
+// setting it per-repo is how the estate ended up with inconsistent max-ages.
+// Permissions-Policy deliberately omits accelerometer/gyroscope/magnetometer:
+// a top-level policy is inherited by iframes and cannot be widened by their
+// `allow` attribute, so blocking those breaks embedded video players.
+const securityHeaders = [
+  { key: 'X-Frame-Options', value: 'DENY' },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+  {
+    key: 'Permissions-Policy',
+    value: [
+      'camera=()',
+      'microphone=()',
+      'geolocation=()',
+      'payment=()',
+      'usb=()',
+      'bluetooth=()',
+    ].join(', '),
+  },
+];
+
 /** @type {import('next').NextConfig} */
 const config = {
   reactStrictMode: true,
+  // Only applied to the server-rendered build. `output: 'export'` has no
+  // server to send headers, and Next drops `headers()` silently — the Apache
+  // vhost serving the static build needs these set there instead.
+  ...(!isStatic && {
+    async headers() {
+      return [{ source: '/(.*)', headers: securityHeaders }];
+    },
+  }),
   // Static-export build for LAMP/Apache hosting under `/mvdocs`.
   // Enabled by `STATIC_EXPORT=true` (see `pnpm build:static`).
   // Search bar is hidden in static mode (no backend); the Fumadocs search


### PR DESCRIPTION
## Problem

The Next config has no `headers()` block, so responses carry no `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, or `Permissions-Policy`. Without frame protection the app can be embedded by any origin, which is a clickjacking surface.

## Change

Adds those four headers site-wide. Config only — no runtime code changes.

- No `Strict-Transport-Security`: the hosting platform already sends it.
- `Permissions-Policy` omits `accelerometer`, `gyroscope`, and `magnetometer`. A top-level policy is inherited by nested iframes and cannot be widened by their `allow` attribute, so denying those breaks embedded video players that request them.

## Checks

Nothing in this app expects to be framed (no `postMessage`, `window.parent`, or `window.top`, no embed routes) and nothing uses the denied features (no `getUserMedia`, Payment Request, WebUSB, or Web Bluetooth).

Not answerable from source: whether an external party embeds this app in an iframe. If a partner integration does, `X-Frame-Options: DENY` will break it.

## Static export

The block is gated behind the static check. When `STATIC_EXPORT=true` sets `output: 'export'` there is no server to send headers and Next drops `headers()` silently, so including it unconditionally would only add a build warning. The Apache vhost serving the static output needs these four headers set there instead; this PR does not cover that deployment.

## Verified

`pnpm build` completes and a production server returns all four headers. `pnpm build:static` completes clean with no headers warning.
