### PR TITLE
docs: update GitHub org links to movement-network, fix Discord invite and aptos-core branch refs

### DIFF
--- a/content/docs/api/index.mdx
+++ b/content/docs/api/index.mdx
@@ -11,7 +11,7 @@ The Movement Full Node API is a RESTful API for client applications to interact 
 
 **Move Industries:**
 
-URL: https://github.com/movementlabsxyz/movement
+URL: https://github.com/movement-network/movement
 
 ## License
 

--- a/content/docs/api/spec.yaml
+++ b/content/docs/api/spec.yaml
@@ -8,7 +8,7 @@ info:
   version: 1.2.0
   contact:
     name: Movement Labs
-    url: https://github.com/movementlabsxyz/movement
+    url: https://github.com/movement-network/movement
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html

--- a/content/docs/api/spec_fixed.yaml
+++ b/content/docs/api/spec_fixed.yaml
@@ -8,7 +8,7 @@ info:
   version: 1.2.0
   contact:
     name: Movement Labs
-    url: https://github.com/movementlabsxyz/movement
+    url: https://github.com/movement-network/movement
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html

--- a/content/docs/devs/indexing.mdx
+++ b/content/docs/devs/indexing.mdx
@@ -301,7 +301,7 @@ dpkg -i grpcurl_1.9.2_linux_amd64.deb
 ```bash
 HOME=/home/ssm-user
 cd "${HOME}"
-git clone https://github.com/movementlabsxyz/movement/
+git clone https://github.com/movement-network/movement/
 ```
 
 ### 3. Create required config directories and files
@@ -536,7 +536,7 @@ cd "${HOME}"/movement/docker/compose/movement-indexer
 cat << 'EOF' > .env
 services:
   movement-indexer:
-    image: ghcr.io/movementlabsxyz/movement-indexer:${CONTAINER_REV}
+    image: ghcr.io/movement-network/movement-indexer:${CONTAINER_REV}
     # entrypoint: '/bin/sh -c "tail -f /dev/null"'
     container_name: movement-indexer
     environment:

--- a/content/docs/devs/move-book/package.mdx
+++ b/content/docs/devs/move-book/package.mdx
@@ -61,7 +61,7 @@ hello_blockchain = "0xc48ec9d15e56d71e035333c7d1d7c3c80d66210a940f6583d63a63608a
 [dev-addresses]
 
 [dependencies.AptosFramework]
-git = "https://github.com/movementlabsxyz/aptos-core.git"
+git = "https://github.com/movement-network/aptos-core.git"
 rev = "movement"
 subdir = "aptos-move/framework/aptos-framework"
 
@@ -78,7 +78,7 @@ subdir = "aptos-move/framework/aptos-framework"
 
 ```toml
 [dependencies.AptosFramework]
-git = "https://github.com/movementlabsxyz/aptos-core.git"
+git = "https://github.com/movement-network/aptos-core.git"
 rev = "movement"
 subdir = "aptos-move/framework/aptos-framework"
 

--- a/content/docs/devs/movementcli.mdx
+++ b/content/docs/devs/movementcli.mdx
@@ -66,7 +66,7 @@ When developing on Movement, it is recommended to use the `movement` CLI.
 
 ### Binary Install
 ```
-git clone https://github.com/movementlabsxyz/aptos-core/ && cd aptos-core
+git clone https://github.com/movement-network/aptos-core/ && cd aptos-core
 ```
 ```
 cargo build -p movement
@@ -99,4 +99,4 @@ or
 movement <subcommand> --help
 ```
 
-Developers who would like to contribute or read the source code, please see [the Movement CLI crate](https://github.com/movementlabsxyz/aptos-core/tree/movement/crates/aptos).
+Developers who would like to contribute or read the source code, please see [the Movement CLI crate](https://github.com/movement-network/aptos-core/tree/movement/crates/aptos).

--- a/content/docs/devs/tokenStandard/legacyStandard/coin.mdx
+++ b/content/docs/devs/tokenStandard/legacyStandard/coin.mdx
@@ -5,7 +5,7 @@ description: Learn about the legacy Coin standard for fungible token development
 
 # Coin (Legacy Standard)
 
-The [Coin standard](https://github.com/movement-network/aptos-core/blob/main/aptos-move/framework/aptos-framework/sources/coin.move) provides a robust, type-safe framework for creating fungible tokens on Movement. Built on Move's phantom type system, it enables developers to create distinct coin types while leveraging shared infrastructure.
+The [Coin standard](https://github.com/movement-network/aptos-core/blob/m1/aptos-move/framework/aptos-framework/sources/coin.move) provides a robust, type-safe framework for creating fungible tokens on Movement. Built on Move's phantom type system, it enables developers to create distinct coin types while leveraging shared infrastructure.
 
 <Callout type="info">
 The Coin standard is available in the Movement framework at `0x1::coin`.

--- a/content/docs/devs/tokenStandard/legacyStandard/coin.mdx
+++ b/content/docs/devs/tokenStandard/legacyStandard/coin.mdx
@@ -5,7 +5,7 @@ description: Learn about the legacy Coin standard for fungible token development
 
 # Coin (Legacy Standard)
 
-The [Coin standard](https://github.com/movementlabsxyz/aptos-core/blob/main/aptos-move/framework/aptos-framework/sources/coin.move) provides a robust, type-safe framework for creating fungible tokens on Movement. Built on Move's phantom type system, it enables developers to create distinct coin types while leveraging shared infrastructure.
+The [Coin standard](https://github.com/movement-network/aptos-core/blob/main/aptos-move/framework/aptos-framework/sources/coin.move) provides a robust, type-safe framework for creating fungible tokens on Movement. Built on Move's phantom type system, it enables developers to create distinct coin types while leveraging shared infrastructure.
 
 <Callout type="info">
 The Coin standard is available in the Movement framework at `0x1::coin`.
@@ -74,7 +74,7 @@ module 0x1::coin {
 
 ## Movement Framework Structures
 
-The following tables describe the core structures in Movement's coin implementation. For the complete reference, see the [Movement Framework Documentation](https://github.com/movementlabsxyz/aptos-core/blob/movement/aptos-move/framework/aptos-framework/doc/coin.md).
+The following tables describe the core structures in Movement's coin implementation. For the complete reference, see the [Movement Framework Documentation](https://github.com/movement-network/aptos-core/blob/movement/aptos-move/framework/aptos-framework/doc/coin.md).
 
 ### [`Coin<CoinType>`]
 

--- a/content/docs/devs/tokenStandard/legacyStandard/token.mdx
+++ b/content/docs/devs/tokenStandard/legacyStandard/token.mdx
@@ -5,7 +5,7 @@ description: Learn about the legacy Token standard for multi-token development o
 
 # Token (Legacy Standard)
 
-The [Token standard](https://github.com/movement-network/aptos-core/blob/main/aptos-move/framework/aptos-token/sources/token.move) provides a comprehensive framework for creating and managing collections of tokens on Movement. This standard supports fungible tokens (FTs), non-fungible tokens (NFTs), and semi-fungible tokens (SFTs) within a unified system, enabling creators to build complex token ecosystems with rich metadata and customizable properties.
+The [Token standard](https://github.com/movement-network/aptos-core/blob/m1/aptos-move/framework/aptos-token/sources/token.move) provides a comprehensive framework for creating and managing collections of tokens on Movement. This standard supports fungible tokens (FTs), non-fungible tokens (NFTs), and semi-fungible tokens (SFTs) within a unified system, enabling creators to build complex token ecosystems with rich metadata and customizable properties.
 
 <Callout type="info">
 The Token standard is available in the Movement framework at `aptos_token::token`.

--- a/content/docs/devs/tokenStandard/legacyStandard/token.mdx
+++ b/content/docs/devs/tokenStandard/legacyStandard/token.mdx
@@ -5,7 +5,7 @@ description: Learn about the legacy Token standard for multi-token development o
 
 # Token (Legacy Standard)
 
-The [Token standard](https://github.com/movementlabsxyz/aptos-core/blob/main/aptos-move/framework/aptos-token/sources/token.move) provides a comprehensive framework for creating and managing collections of tokens on Movement. This standard supports fungible tokens (FTs), non-fungible tokens (NFTs), and semi-fungible tokens (SFTs) within a unified system, enabling creators to build complex token ecosystems with rich metadata and customizable properties.
+The [Token standard](https://github.com/movement-network/aptos-core/blob/main/aptos-move/framework/aptos-token/sources/token.move) provides a comprehensive framework for creating and managing collections of tokens on Movement. This standard supports fungible tokens (FTs), non-fungible tokens (NFTs), and semi-fungible tokens (SFTs) within a unified system, enabling creators to build complex token ecosystems with rich metadata and customizable properties.
 
 <Callout type="info">
 The Token standard is available in the Movement framework at `aptos_token::token`.

--- a/content/docs/devs/tokenStandard/overview.mdx
+++ b/content/docs/devs/tokenStandard/overview.mdx
@@ -64,7 +64,7 @@ While current standards are recommended for all new development, legacy standard
 
 ### Token (Legacy)
 
-The [Token](https://github.com/movement-network/aptos-core/blob/main/aptos-move/framework/aptos-token/sources/token.move) standard provides a versatile framework for managing multiple token types within a single implementation.
+The [Token](https://github.com/movement-network/aptos-core/blob/m1/aptos-move/framework/aptos-token/sources/token.move) standard provides a versatile framework for managing multiple token types within a single implementation.
 
 - **Versatile multi-token support** - Handles NFTs, fungibles, and semi-fungibles in a single standard
 - **Customizable properties** - Offers flexible on-chain property configuration
@@ -72,7 +72,7 @@ The [Token](https://github.com/movement-network/aptos-core/blob/main/aptos-move/
 
 ### Coin (Legacy)
 
-The [Coin](https://github.com/movement-network/aptos-core/blob/main/aptos-move/framework/aptos-framework/sources/coin.move) standard offers a straightforward approach to fungible token implementation with high performance and low gas overhead.
+The [Coin](https://github.com/movement-network/aptos-core/blob/m1/aptos-move/framework/aptos-framework/sources/coin.move) standard offers a straightforward approach to fungible token implementation with high performance and low gas overhead.
 
 - **Simple fungible implementation** - Straightforward token standard for fungible assets
 - **Superseded standard** - Replaced by the more capable Fungible Asset standard

--- a/content/docs/devs/tokenStandard/overview.mdx
+++ b/content/docs/devs/tokenStandard/overview.mdx
@@ -64,7 +64,7 @@ While current standards are recommended for all new development, legacy standard
 
 ### Token (Legacy)
 
-The [Token](https://github.com/movementlabsxyz/aptos-core/blob/main/aptos-move/framework/aptos-token/sources/token.move) standard provides a versatile framework for managing multiple token types within a single implementation.
+The [Token](https://github.com/movement-network/aptos-core/blob/main/aptos-move/framework/aptos-token/sources/token.move) standard provides a versatile framework for managing multiple token types within a single implementation.
 
 - **Versatile multi-token support** - Handles NFTs, fungibles, and semi-fungibles in a single standard
 - **Customizable properties** - Offers flexible on-chain property configuration
@@ -72,7 +72,7 @@ The [Token](https://github.com/movementlabsxyz/aptos-core/blob/main/aptos-move/f
 
 ### Coin (Legacy)
 
-The [Coin](https://github.com/movementlabsxyz/aptos-core/blob/main/aptos-move/framework/aptos-framework/sources/coin.move) standard offers a straightforward approach to fungible token implementation with high performance and low gas overhead.
+The [Coin](https://github.com/movement-network/aptos-core/blob/main/aptos-move/framework/aptos-framework/sources/coin.move) standard offers a straightforward approach to fungible token implementation with high performance and low gas overhead.
 
 - **Simple fungible implementation** - Straightforward token standard for fungible assets
 - **Superseded standard** - Replaced by the more capable Fungible Asset standard

--- a/content/docs/devs/tutorials/build.mdx
+++ b/content/docs/devs/tutorials/build.mdx
@@ -13,7 +13,7 @@ Make sure to have [Movement CLI](/devs/movementcli) installed.
 If you are using Aptos CLI - ensure that you are using version 3.5 or lower.
 </Callout>
 
-View an example of the finished dApp [here](https://github.com/movementlabsxyz/onchain-bio-dapp).
+View an example of the finished dApp [here](https://github.com/movement-network/onchain-bio-dapp).
 
 ## Initialize your Environment 
 

--- a/content/docs/devs/tutorials/move_slayers.mdx
+++ b/content/docs/devs/tutorials/move_slayers.mdx
@@ -5,7 +5,7 @@ description: Build an on-chain RPG with Move
 
 # 🎮 Building an On-Chain RPG with Move: A Complete Educational Guide
 
-This guide walks through every line of code in the [`move_slayers`](https://github.com/movementlabsxyz/move-slayers) game, explaining how to build an on-chain RPG using the Move language on Movement.
+This guide walks through every line of code in the [`move_slayers`](https://github.com/movement-network/move-slayers) game, explaining how to build an on-chain RPG using the Move language on Movement.
 
 ## 📚 What You'll Learn
 

--- a/content/docs/devs/tutorials/stablecoin.mdx
+++ b/content/docs/devs/tutorials/stablecoin.mdx
@@ -9,7 +9,7 @@ This code is not audited, if you are building on this code, ensure that you comp
 
 In this tutorial, we'll build **mFUSD** - a collateralized stablecoin on the Movement Network. This stablecoin maintains a 1:1 peg with USD through over-collateralization with APT tokens.
 
-If you would like to see the finished code, you can find it [here](https://github.com/movementlabsxyz/movement-defi-examples).
+If you would like to see the finished code, you can find it [here](https://github.com/movement-network/movement-defi-examples).
 
 The finished code also includes a module for a more basic fiat backed stablecoin.
 

--- a/content/docs/devs/tutorials/uniswap_v2_example.mdx
+++ b/content/docs/devs/tutorials/uniswap_v2_example.mdx
@@ -11,7 +11,7 @@ This code is not audited, if you are building on this code, ensure that you comp
 
 A complete, production-ready Automated Market Maker (AMM) implementation built for Movement. This project demonstrates advanced DeFi mechanics including constant product formula pools, LP token management, and factory registry patterns.
 
-The complete Movement DeFi Examples repository can be found [here](https://github.com/movementlabsxyz/movement-defi-examples)
+The complete Movement DeFi Examples repository can be found [here](https://github.com/movement-network/movement-defi-examples)
 ## 🚀 Quick Start
 
 ### Prerequisites
@@ -24,7 +24,7 @@ The complete Movement DeFi Examples repository can be found [here](https://githu
 
 1. **Clone the repository:**
    ```bash
-   git clone https://github.com/movementlabsxyz/movement-defi-examples.git
+   git clone https://github.com/movement-network/movement-defi-examples.git
    cd univ2
    ```
 

--- a/content/docs/general/l1/nodes/public-fullnode.mdx
+++ b/content/docs/general/l1/nodes/public-fullnode.mdx
@@ -18,7 +18,7 @@ PFNs will enable various use cases including:
 
 **Default connection to mainnet**: If you follow the default setup in this document, then your PFN will be connected to the Movement mainnet. To connect to a different Movement network, such as testnet, make sure you have the correct configuration files and genesis data.
 
-You can find the genesis and waypoint files for all Movement networks in the **[Movement Networks repository](https://github.com/movementlabsxyz/movement-networks)**.
+You can find the genesis and waypoint files for all Movement networks in the **[Movement Networks repository](https://github.com/movement-network/movement-networks)**.
 
 ## Overview
 

--- a/content/docs/general/l1/nodes/validator-node.mdx
+++ b/content/docs/general/l1/nodes/validator-node.mdx
@@ -14,4 +14,4 @@ When validator nodes become available, they will have specific hardware and soft
 
 To be notified when validator functionality becomes available:
 - **[Follow on Discord](https://discord.com/invite/moveindustries)** - Join the community
-- **[Monitor GitHub](https://github.com/movementlabsxyz/movement)** - Track development progress
+- **[Monitor GitHub](https://github.com/movement-network/movement)** - Track development progress

--- a/content/docs/general/l1/nodes/validator-node/validator-fullnode.mdx.bak
+++ b/content/docs/general/l1/nodes/validator-node/validator-fullnode.mdx.bak
@@ -504,4 +504,4 @@ VFNs work best as part of a complete validator setup:
 - **[VFN Troubleshooting](/general/nodes/validator-node/vfn-troubleshooting)** - VFN-specific issues
 - **[Performance Optimization](/general/nodes/validator-node/vfn-performance)** - VFN tuning guides  
 - **[API Documentation](/api/node)** - Complete API reference
-- **[Community Discord](https://discord.gg/movementlabsxyz)** - Get help from other operators
+- **[Community Discord](https://discord.gg/movementxyz)** - Get help from other operators

--- a/content/docs/general/l1/nodes/validator-node/validator-fullnode.mdx.bak
+++ b/content/docs/general/l1/nodes/validator-node/validator-fullnode.mdx.bak
@@ -198,8 +198,8 @@ sudo apt install wireguard
 ### 5. Download Network Configuration
 ```bash
 # Download the same genesis as your validator
-wget https://github.com/movementlabsxyz/movement-networks/raw/main/mainnet/genesis.blob
-wget https://github.com/movementlabsxyz/movement-networks/raw/main/mainnet/waypoint.txt
+wget https://github.com/movement-network/movement-networks/raw/main/mainnet/genesis.blob
+wget https://github.com/movement-network/movement-networks/raw/main/mainnet/waypoint.txt
 
 # Verify integrity
 sha256sum genesis.blob waypoint.txt

--- a/content/docs/general/l1/nodes/validator-node/validator.mdx.bak
+++ b/content/docs/general/l1/nodes/validator-node/validator.mdx.bak
@@ -330,7 +330,7 @@ After setting up your validator node:
 
 1. **Set Up VFN**: Deploy a **[Validator Fullnode](/general/nodes/validator-fullnode)** for public access
 2. **Configure Monitoring**: Set up **[monitoring and alerting](/general/nodes/validator-node/monitoring)**
-3. **Join Community**: Connect with other validators on **[Discord](https://discord.gg/movementlabsxyz)**
+3. **Join Community**: Connect with other validators on **[Discord](https://discord.gg/movementxyz)**
 4. **Ongoing Operations**: Review **[validator operations guide](/general/nodes/validator-node/operations)**
 
 ## Support Resources

--- a/content/docs/general/l1/nodes/validator-node/validator.mdx.bak
+++ b/content/docs/general/l1/nodes/validator-node/validator.mdx.bak
@@ -138,8 +138,8 @@ api:
 ### 4. Download Network Configuration
 ```bash
 # Download genesis and waypoint for target network
-wget https://github.com/movementlabsxyz/movement-networks/raw/main/mainnet/genesis.blob
-wget https://github.com/movementlabsxyz/movement-networks/raw/main/mainnet/waypoint.txt
+wget https://github.com/movement-network/movement-networks/raw/main/mainnet/genesis.blob
+wget https://github.com/movement-network/movement-networks/raw/main/mainnet/waypoint.txt
 
 # Verify checksums
 sha256sum genesis.blob waypoint.txt

--- a/content/docs/general/nodes/archival-node/run/deploy/docker.mdx
+++ b/content/docs/general/nodes/archival-node/run/deploy/docker.mdx
@@ -36,19 +36,19 @@ Download the archival fullnode configuration and genesis files:
 ### For Mainnet
 
 ```shellscript filename="Terminal"
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/mainnet/configs/archival-fullnode.yaml
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/mainnet/genesis.blob
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/mainnet/waypoint.txt
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/mainnet/genesis_waypoint.txt
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/mainnet/configs/archival-fullnode.yaml
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/mainnet/genesis.blob
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/mainnet/waypoint.txt
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/mainnet/genesis_waypoint.txt
 ```
 
 ### For Testnet
 
 ```shellscript filename="Terminal"
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/testnet/configs/archival-fullnode.yaml
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/testnet/genesis.blob
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/testnet/waypoint.txt
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/testnet/genesis_waypoint.txt
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/testnet/configs/archival-fullnode.yaml
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/testnet/genesis.blob
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/testnet/waypoint.txt
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/testnet/genesis_waypoint.txt
 ```
 
 ## Step 3: Restore Data from Backup
@@ -57,7 +57,7 @@ Restore blockchain data from Move Industries' public backups using the restore s
 
 ```shellscript filename="Terminal"
 # Download the restore script
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/l1_restore.sh
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/l1_restore.sh
 chmod +x l1_restore.sh
 
 # Restore data (use 'mainnet' or 'testnet')
@@ -86,7 +86,7 @@ docker run --pull=always \
   -v $(pwd)/data:/opt/aptos/data \
   --workdir /opt/aptos \
   --name=aptos-archival-node \
-  ghcr.io/movementlabsxyz/aptos-node:f24a5bc \
+  ghcr.io/movement-network/aptos-node:f24a5bc \
   -f /opt/aptos/archival-fullnode.yaml
 ```
 
@@ -103,7 +103,7 @@ docker run --pull=always -d \
   -v $(pwd)/data:/opt/aptos/data \
   --workdir /opt/aptos \
   --name=aptos-archival-node \
-  ghcr.io/movementlabsxyz/aptos-node:f24a5bc \
+  ghcr.io/movement-network/aptos-node:f24a5bc \
   -f /opt/aptos/archival-fullnode.yaml
 ```
 

--- a/content/docs/general/nodes/archival-node/run/deploy/index.mdx
+++ b/content/docs/general/nodes/archival-node/run/deploy/index.mdx
@@ -52,7 +52,7 @@ Download and run the restore script from the Movement Networks repository:
 
 ```shellscript filename="Terminal"
 # Download the restore script
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/l1_restore.sh
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/l1_restore.sh
 chmod +x l1_restore.sh
 
 # Restore mainnet data (~700GB)
@@ -78,20 +78,20 @@ Download the archival fullnode configuration and genesis files:
 
 ```shellscript filename="Terminal"
 mkdir -p mainnet-archival && cd mainnet-archival
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/mainnet/configs/archival-fullnode.yaml
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/mainnet/genesis.blob
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/mainnet/waypoint.txt
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/mainnet/genesis_waypoint.txt
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/mainnet/configs/archival-fullnode.yaml
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/mainnet/genesis.blob
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/mainnet/waypoint.txt
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/mainnet/genesis_waypoint.txt
 ```
 
 ### For Testnet
 
 ```shellscript filename="Terminal"
 mkdir -p testnet-archival && cd testnet-archival
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/testnet/configs/archival-fullnode.yaml
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/testnet/genesis.blob
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/testnet/waypoint.txt
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/testnet/genesis_waypoint.txt
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/testnet/configs/archival-fullnode.yaml
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/testnet/genesis.blob
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/testnet/waypoint.txt
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/testnet/genesis_waypoint.txt
 ```
 
 ## Next Steps

--- a/content/docs/general/nodes/archival-node/run/deploy/source.mdx
+++ b/content/docs/general/nodes/archival-node/run/deploy/source.mdx
@@ -25,7 +25,7 @@ sudo apt install -y binutils build-essential lld pkg-config libdw-dev
 
 ```shellscript filename="Terminal"
 # Clone the Movement aptos-core repository
-git clone https://github.com/movementlabsxyz/aptos-core.git
+git clone https://github.com/movement-network/aptos-core.git
 cd aptos-core
 
 # Check out the l1-migration branch
@@ -48,19 +48,19 @@ Download the archival fullnode configuration and genesis files:
 ### For Mainnet
 
 ```shellscript filename="Terminal"
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/mainnet/configs/archival-fullnode.yaml
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/mainnet/genesis.blob
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/mainnet/waypoint.txt
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/mainnet/genesis_waypoint.txt
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/mainnet/configs/archival-fullnode.yaml
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/mainnet/genesis.blob
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/mainnet/waypoint.txt
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/mainnet/genesis_waypoint.txt
 ```
 
 ### For Testnet
 
 ```shellscript filename="Terminal"
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/testnet/configs/archival-fullnode.yaml
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/testnet/genesis.blob
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/testnet/waypoint.txt
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/testnet/genesis_waypoint.txt
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/testnet/configs/archival-fullnode.yaml
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/testnet/genesis.blob
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/testnet/waypoint.txt
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/testnet/genesis_waypoint.txt
 ```
 
 ## Step 3: Update Configuration Paths
@@ -106,7 +106,7 @@ Restore blockchain data from Move Industries' public backups using the restore s
 
 ```shellscript filename="Terminal"
 # Download the restore script
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/l1_restore.sh
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/l1_restore.sh
 chmod +x l1_restore.sh
 
 # Restore data (use 'mainnet' or 'testnet')

--- a/content/docs/general/nodes/archival-node/run/index.mdx
+++ b/content/docs/general/nodes/archival-node/run/index.mdx
@@ -92,7 +92,7 @@ Download and use the restore script from the Movement Networks repository:
 
 ```shellscript filename="Terminal"
 # Download the restore script
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/l1_restore.sh
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/l1_restore.sh
 chmod +x l1_restore.sh
 
 # Restore mainnet data

--- a/content/docs/general/nodes/full-node/index.mdx
+++ b/content/docs/general/nodes/full-node/index.mdx
@@ -15,5 +15,5 @@ If you follow the default setup in this document, then your PFN will be connecte
 to a different Movement network, such as testnet or mainnet, make sure you have the correct docker image tag, or source
 code branch if you build the binary directly.
 
-You can find the genesis and waypoint files for all the networks, here ➜ https://github.com/movementlabsxyz/movement-networks.
+You can find the genesis and waypoint files for all the networks, here ➜ https://github.com/movement-network/movement-networks.
 

--- a/content/docs/general/nodes/full-node/run/deploy/docker.mdx
+++ b/content/docs/general/nodes/full-node/run/deploy/docker.mdx
@@ -27,10 +27,10 @@ Download the fullnode configuration and genesis files for your network:
 ```shellscript filename="Terminal"
 mkdir -p mainnet && cd mainnet
 mkdir -p data
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/mainnet/configs/fullnode.yaml
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/mainnet/genesis.blob
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/mainnet/waypoint.txt
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/mainnet/genesis_waypoint.txt
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/mainnet/configs/fullnode.yaml
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/mainnet/genesis.blob
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/mainnet/waypoint.txt
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/mainnet/genesis_waypoint.txt
 ```
 
 ### For Testnet
@@ -38,16 +38,16 @@ curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main
 ```shellscript filename="Terminal"
 mkdir -p testnet && cd testnet
 mkdir -p data
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/testnet/configs/fullnode.yaml
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/testnet/genesis.blob
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/testnet/waypoint.txt
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/testnet/genesis_waypoint.txt
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/testnet/configs/fullnode.yaml
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/testnet/genesis.blob
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/testnet/waypoint.txt
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/testnet/genesis_waypoint.txt
 ```
 
 <Callout type="info">
 **Genesis files repository**
 
-All configuration and genesis files are maintained at https://github.com/movementlabsxyz/movement-networks
+All configuration and genesis files are maintained at https://github.com/movement-network/movement-networks
 </Callout>
 
 ## Step 2: Run the Fullnode
@@ -62,7 +62,7 @@ docker run --pull=always \
   -v $(pwd)/data:/opt/aptos/data \
   --workdir /opt/aptos \
   --name=aptos-fullnode \
-  ghcr.io/movementlabsxyz/aptos-node:f24a5bc \
+  ghcr.io/movement-network/aptos-node:f24a5bc \
   -f /opt/aptos/fullnode.yaml
 ```
 
@@ -79,7 +79,7 @@ docker run --pull=always -d \
   -v $(pwd)/data:/opt/aptos/data \
   --workdir /opt/aptos \
   --name=aptos-fullnode \
-  ghcr.io/movementlabsxyz/aptos-node:f24a5bc \
+  ghcr.io/movement-network/aptos-node:f24a5bc \
   -f /opt/aptos/fullnode.yaml
 ```
 
@@ -161,8 +161,8 @@ listen_address: "/ip4/127.0.0.1/tcp/6182"
 ## Docker Tags
 
 The `latest` tag always refers to the latest official Docker image. You can find the current version at:
-- Mainnet: https://github.com/movementlabsxyz/movement-networks/tree/main/mainnet
-- Testnet: https://github.com/movementlabsxyz/movement-networks/tree/main/testnet
+- Mainnet: https://github.com/movement-network/movement-networks/tree/main/mainnet
+- Testnet: https://github.com/movement-network/movement-networks/tree/main/testnet
 
 ## Next Steps
 

--- a/content/docs/general/nodes/full-node/run/deploy/index.mdx
+++ b/content/docs/general/nodes/full-node/run/deploy/index.mdx
@@ -21,10 +21,10 @@ Select the guide for the deployment method you prefer:
 **Choose a network**<br />
 These guides default to deploying a PFN in the Movement for mainnet or testnet network.
 To find all configuration files for all Movement networks, check out the 
-[movement-networks](https://github.com/movementlabsxyz/movement-networks) repo
+[movement-networks](https://github.com/movement-network/movement-networks) repo
 and use the `genesis.blob` and `waypoint.txt` node files for the respective networks:
-[mainnet](https://github.com/movementlabsxyz/movement-networks/blob/main/mainnet/README.md)
-and [testnet](https://github.com/movementlabsxyz/movement-networks/blob/main/testnet/README.md).
+[mainnet](https://github.com/movement-network/movement-networks/blob/main/mainnet/README.md)
+and [testnet](https://github.com/movement-network/movement-networks/blob/main/testnet/README.md).
 </Callout>
 
 - ### [Using Source Code](/general/nodes/full-node/run/deploy/source)

--- a/content/docs/general/nodes/full-node/run/deploy/source.mdx
+++ b/content/docs/general/nodes/full-node/run/deploy/source.mdx
@@ -24,7 +24,7 @@ sudo apt install -y binutils build-essential lld pkg-config libdw-dev
 
 ```shellscript filename="Terminal"
 # Clone the Movement aptos-core repository
-git clone https://github.com/movementlabsxyz/aptos-core.git
+git clone https://github.com/movement-network/aptos-core.git
 cd aptos-core
 
 # Check out the l1-migration branch
@@ -47,25 +47,25 @@ Download the fullnode configuration and genesis files for your network:
 ### For Mainnet
 
 ```shellscript filename="Terminal"
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/mainnet/configs/fullnode.yaml
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/mainnet/genesis.blob
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/mainnet/waypoint.txt
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/mainnet/genesis_waypoint.txt
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/mainnet/configs/fullnode.yaml
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/mainnet/genesis.blob
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/mainnet/waypoint.txt
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/mainnet/genesis_waypoint.txt
 ```
 
 ### For Testnet
 
 ```shellscript filename="Terminal"
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/testnet/configs/fullnode.yaml
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/testnet/genesis.blob
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/testnet/waypoint.txt
-curl -O https://raw.githubusercontent.com/movementlabsxyz/movement-networks/main/testnet/genesis_waypoint.txt
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/testnet/configs/fullnode.yaml
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/testnet/genesis.blob
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/testnet/waypoint.txt
+curl -O https://raw.githubusercontent.com/movement-network/movement-networks/main/testnet/genesis_waypoint.txt
 ```
 
 <Callout type="info">
 **Genesis files repository**
 
-All configuration and genesis files are maintained at https://github.com/movementlabsxyz/movement-networks
+All configuration and genesis files are maintained at https://github.com/movement-network/movement-networks
 </Callout>
 
 ## Step 3: Update Configuration Paths

--- a/content/docs/general/nodes/full-node/run/index.mdx
+++ b/content/docs/general/nodes/full-node/run/index.mdx
@@ -33,7 +33,7 @@ the only network type that a PFN uses is the public network, where PFNs to conne
 
 Your PFN can be configured so that the public network operates using a specific port on your node. You can configure
 the port settings using the node configuration YAML file. Here is an [example
-configuration file](https://github.com/movementlabsxyz/aptos-core/blob/movement/config/src/config/test_data/public_full_node.yaml#L16) for a PFN
+configuration file](https://github.com/movement-network/aptos-core/blob/movement/config/src/config/test_data/public_full_node.yaml#L16) for a PFN
 that configures the public network to use port `6180`.
 
 ### Port settings

--- a/content/docs/general/nodes/full-node/run/verify.mdx
+++ b/content/docs/general/nodes/full-node/run/verify.mdx
@@ -89,6 +89,6 @@ docker exec -it $id /bin/bash
 du -cs -BM /opt/aptos/data
 ```
 
-[rest_spec]: https://github.com/movementlabsxyz/aptos-core/tree/main/api
+[rest_spec]: https://github.com/movement-network/aptos-core/tree/main/api
 
-[movementlabsxyz/aptos-core]: https://github.com/movementlabsxyz/aptos-core.git
+[movement-network/aptos-core]: https://github.com/movement-network/aptos-core.git

--- a/content/docs/general/nodes/full-node/run/verify.mdx
+++ b/content/docs/general/nodes/full-node/run/verify.mdx
@@ -89,6 +89,6 @@ docker exec -it $id /bin/bash
 du -cs -BM /opt/aptos/data
 ```
 
-[rest_spec]: https://github.com/movement-network/aptos-core/tree/main/api
+[rest_spec]: https://github.com/movement-network/aptos-core/tree/m1/api
 
 [movement-network/aptos-core]: https://github.com/movement-network/aptos-core.git

--- a/content/docs/general/nodes/index.mdx
+++ b/content/docs/general/nodes/index.mdx
@@ -42,4 +42,4 @@ An **archival fullnode** maintains complete blockchain history from genesis by d
 ## Additional Resources
 
 - [M1 Node Types](/general/l1/nodes) - Learn about validator and VFN nodes
-- [Genesis Files](https://github.com/movementlabsxyz/movement-networks) - Download genesis and configuration files
+- [Genesis Files](https://github.com/movement-network/movement-networks) - Download genesis and configuration files

--- a/content/docs/general/usingmovement/community-support.mdx
+++ b/content/docs/general/usingmovement/community-support.mdx
@@ -16,10 +16,10 @@ import React from 'react';
 ## Support Channels
 
 - **[Discord Community](https://discord.com/invite/moveindustries)** - Real-time support and discussion
-- **[GitHub Issues](https://github.com/movementlabsxyz/movement)** - Bug reports and feature requests
+- **[GitHub Issues](https://github.com/movement-network/movement)** - Bug reports and feature requests
 - **Office Hours** - Regular developer support sessions
 
 ## Stay Updated
 
 - **[X (Twitter)](https://x.com/movement_xyz)** - Latest news and developments
-- **[GitHub](https://github.com/movementlabsxyz/movement)** - Technical updates and releases
+- **[GitHub](https://github.com/movement-network/movement)** - Technical updates and releases

--- a/docs/devs/indexing.md
+++ b/docs/devs/indexing.md
@@ -305,7 +305,7 @@ dpkg -i grpcurl_1.9.2_linux_amd64.deb
 ```bash
 HOME=/home/ssm-user
 cd "${HOME}"
-git clone https://github.com/movementlabsxyz/movement/
+git clone https://github.com/movement-network/movement/
 ```
 
 ### 3. Create required config directories and files
@@ -540,7 +540,7 @@ cd "${HOME}"/movement/docker/compose/movement-indexer
 cat << 'EOF' > .env
 services:
   movement-indexer:
-    image: ghcr.io/movementlabsxyz/movement-indexer:${CONTAINER_REV}
+    image: ghcr.io/movement-network/movement-indexer:${CONTAINER_REV}
     # entrypoint: '/bin/sh -c "tail -f /dev/null"'
     container_name: movement-indexer
     environment:

--- a/public/api-spec.yaml
+++ b/public/api-spec.yaml
@@ -8,7 +8,7 @@ info:
   version: 1.2.0
   contact:
     name: Movement Labs
-    url: https://github.com/movementlabsxyz/movement
+    url: https://github.com/movement-network/movement
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html

--- a/public/spec.yaml
+++ b/public/spec.yaml
@@ -8,7 +8,7 @@ info:
   version: 1.2.0
   contact:
     name: Movement Labs
-    url: https://github.com/movementlabsxyz/movement
+    url: https://github.com/movement-network/movement
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html

--- a/src/app/api/[[...slug]]/page.tsx
+++ b/src/app/api/[[...slug]]/page.tsx
@@ -36,7 +36,7 @@ export default async function Page(props: {
           <LLMCopyButton markdownUrl={`${page.url}.mdx`} />
           <ViewOptions
             markdownUrl={`${page.url}.mdx`}
-            githubUrl={`https://github.com/movementlabsxyz/movement-docs/blob/main/content/docs/${page.path}`}
+            githubUrl={`https://github.com/movement-network/movement-docs/blob/main/content/docs/${page.path}`}
           />
         </div>
       )}

--- a/src/app/devs/[[...slug]]/page.tsx
+++ b/src/app/devs/[[...slug]]/page.tsx
@@ -43,7 +43,7 @@ export default async function Page(props: {
           <LLMCopyButton markdownUrl={`${page.url}.mdx`} />
           <ViewOptions
             markdownUrl={`${page.url}.mdx`}
-            githubUrl={`https://github.com/movementlabsxyz/movement-docs/blob/main/content/docs/${page.path}`}
+            githubUrl={`https://github.com/movement-network/movement-docs/blob/main/content/docs/${page.path}`}
           />
         </div>
       )}

--- a/src/app/general/[[...slug]]/page.tsx
+++ b/src/app/general/[[...slug]]/page.tsx
@@ -36,7 +36,7 @@ export default async function Page(props: {
           <LLMCopyButton markdownUrl={`${page.url}.mdx`} />
           <ViewOptions
             markdownUrl={`${page.url}.mdx`}
-            githubUrl={`https://github.com/movementlabsxyz/movement-docs/blob/main/content/docs/${page.path}`}
+            githubUrl={`https://github.com/movement-network/movement-docs/blob/main/content/docs/${page.path}`}
           />
         </div>
       )}

--- a/src/app/layout.config.tsx
+++ b/src/app/layout.config.tsx
@@ -34,7 +34,7 @@ export const baseOptions: BaseLayoutProps = {
       label: 'GitHub Repository',
       icon: <Github />,
       text: 'GitHub',
-      url: 'https://github.com/movementlabsxyz/movement-docs',
+      url: 'https://github.com/movement-network/movement-docs',
     },
     {
       type: 'icon',


### PR DESCRIPTION
## Summary

Updates all references to the old GitHub org name `movementlabsxyz` to `movement-network` following the org rename, fixes the Discord invite links, and points `aptos-core` links at the correct branch.

- Replaces `github.com/movementlabsxyz/...` and `raw.githubusercontent.com/movementlabsxyz/...` URLs across docs content, API specs (`spec.yaml`, `spec_fixed.yaml`, `public/*.yaml`), and app source (`layout.config.tsx`, "edit on GitHub" links in the slug pages).
- Replaces `ghcr.io/movementlabsxyz/...` container image references (`aptos-node`, `movement-indexer`) — unlike github.com, the GitHub Container Registry does **not** redirect old org namespaces, so these were the most important to fix.
- Updates `discord.gg/movementlabsxyz` invite links to `discord.gg/movementxyz`.
- Points `movement-network/aptos-core` links at the `m1` branch instead of `main`; upstream `aptos-labs/aptos-core` links are unchanged.

## Verification

- `github.com/movement-network` org page, the `movement-networks` repo, and a raw.githubusercontent file all return 200 under the new org.
- Both GHCR images verified to exist under the new namespace via manifest/tag API (`aptos-node:f24a5bc` and `movement-indexer` return 200).
- `discord.gg/movementxyz` verified via the Discord invite API: resolves to the Movement server with a non-expiring invite.
- All `m1`-branch paths (coin.move, token.move, api/) verified to exist on that branch.
- `next build` passes with all pages generated.
- No `movementlabsxyz` references remain in tracked files.
