### PR TITLE
[BLOCKED] chore: point moveindustries SDK/Homebrew references at movement-network

### DIFF
--- a/content/docs/devs/interactonchain/near-intents-sdk.mdx
+++ b/content/docs/devs/interactonchain/near-intents-sdk.mdx
@@ -5,7 +5,7 @@ description: Move USDC or USDT from Ethereum, Polygon, or Tron onto Movement ove
 
 # NEAR Intents SDK
 
-The [`@moveindustries/near-intents-sdk`](https://github.com/MoveIndustries/near-intents-sdk) is a thin TypeScript SDK for moving **USDC or USDT** from a supported origin chain onto **Movement** — landing as **USDCx** or **MOVE** — over [NEAR Intents](https://docs.near-intents.org). It wraps the official [1Click API](https://docs.near-intents.org/near-intents/integration/distribution-channels/1click-api) and pins the destination to Movement, so a transfer can't accidentally land on the wrong chain.
+The [`@movement-network/near-intents-sdk`](https://github.com/MoveIndustries/near-intents-sdk) is a thin TypeScript SDK for moving **USDC or USDT** from a supported origin chain onto **Movement** — landing as **USDCx** or **MOVE** — over [NEAR Intents](https://docs.near-intents.org). It wraps the official [1Click API](https://docs.near-intents.org/near-intents/integration/distribution-channels/1click-api) and pins the destination to Movement, so a transfer can't accidentally land on the wrong chain.
 
 It orchestrates the transfer — get a quote, build the deposit, track status — and **never signs, broadcasts, or holds keys**. Your own wallet signs the one on-chain step.
 
@@ -31,19 +31,19 @@ The destination is always Movement. You choose the origin (Ethereum, Polygon, or
 ## Installation
 
 ```bash tab="npm"
-npm install @moveindustries/near-intents-sdk
+npm install @movement-network/near-intents-sdk
 ```
 
 ```bash tab="pnpm"
-pnpm add @moveindustries/near-intents-sdk
+pnpm add @movement-network/near-intents-sdk
 ```
 
 ```bash tab="yarn"
-yarn add @moveindustries/near-intents-sdk
+yarn add @movement-network/near-intents-sdk
 ```
 
 ```bash tab="bun"
-bun add @moveindustries/near-intents-sdk
+bun add @movement-network/near-intents-sdk
 ```
 
 ## Quick start
@@ -58,7 +58,7 @@ import {
   submitDeposit,
   getStatus,
   isTerminal,
-} from "@moveindustries/near-intents-sdk";
+} from "@movement-network/near-intents-sdk";
 
 // configure() is optional — omit it entirely to run token-free (see Authentication).
 configure({ jwt: process.env.ONE_CLICK_JWT });
@@ -204,7 +204,7 @@ The origin wallet needs the chain's **native gas token** to send the deposit (ET
 Each example runs the full flow for one route. They share the `waitForSettlement` helper:
 
 ```ts
-import { getStatus, isTerminal } from "@moveindustries/near-intents-sdk";
+import { getStatus, isTerminal } from "@movement-network/near-intents-sdk";
 
 async function waitForSettlement(depositAddress: string) {
   for (;;) {
@@ -223,7 +223,7 @@ One flow covers both EVM origins — only `originChain` and the viem `chain` dif
 import { createWalletClient, http } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { mainnet } from "viem/chains"; // Polygon: import { polygon }
-import { configure, quoteDeposit, prepareDepositTx, submitDeposit } from "@moveindustries/near-intents-sdk";
+import { configure, quoteDeposit, prepareDepositTx, submitDeposit } from "@movement-network/near-intents-sdk";
 
 // Server-side, JWT stays private:
 configure({ jwt: process.env.ONE_CLICK_JWT }); // optional
@@ -263,7 +263,7 @@ console.log("Settled:", await waitForSettlement(depositAddress!));
 Tron is USDT-only. The deposit is a TRC-20 transfer through the injected `window.tronWeb` provider (TronLink):
 
 ```ts
-import { configure, quoteDeposit, prepareDepositTx, submitDeposit } from "@moveindustries/near-intents-sdk";
+import { configure, quoteDeposit, prepareDepositTx, submitDeposit } from "@movement-network/near-intents-sdk";
 
 configure({ baseUrl: "/api/1click" });
 
@@ -299,7 +299,7 @@ To avoid using `window.tronWeb` directly, use the [TronWallet Adapter](https://g
 ```ts
 import { TronWeb } from "tronweb";
 import { useWallet } from "@tronweb3/tronwallet-adapter-react-hooks";
-import { configure, quoteDeposit, prepareDepositTx, submitDeposit } from "@moveindustries/near-intents-sdk";
+import { configure, quoteDeposit, prepareDepositTx, submitDeposit } from "@movement-network/near-intents-sdk";
 
 configure({ baseUrl: "/api/1click" });
 
@@ -360,7 +360,7 @@ The adapter needs its provider set up once near the root of your app — wrap it
 `listTokens` returns the live set of supported tokens, filtered to the SDK's routes and tagged with the route keys `quoteDeposit` expects — so you can feed a token straight into a quote without any lookup:
 
 ```ts
-import { listTokens } from "@moveindustries/near-intents-sdk";
+import { listTokens } from "@movement-network/near-intents-sdk";
 
 const tokens = await listTokens();
 // each token carries: assetId, symbol, decimals, chain, contractAddress, price,

--- a/content/docs/devs/interactonchain/tsSdk.mdx
+++ b/content/docs/devs/interactonchain/tsSdk.mdx
@@ -18,19 +18,19 @@ The [Movement TypeScript SDK](https://github.com/MoveIndustries/ts-sdk) allows y
 ## Installation
 
 ```bash tab="npm"
-npm install @moveindustries/ts-sdk
+npm install @movement-network/ts-sdk
 ```
 
 ```bash tab="pnpm"
-pnpm add @moveindustries/ts-sdk
+pnpm add @movement-network/ts-sdk
 ```
 
 ```bash tab="yarn"
-yarn add @moveindustries/ts-sdk
+yarn add @movement-network/ts-sdk
 ```
 
 ```bash tab="bun"
-bun add @moveindustries/ts-sdk
+bun add @movement-network/ts-sdk
 ```
 
 ## Imports
@@ -38,7 +38,7 @@ bun add @moveindustries/ts-sdk
 To get started with the SDK, import the necessary components:
 
 ```javascript
-const { Account, Movement, MovementConfig, Network, Ed25519PrivateKey } = require("@moveindustries/ts-sdk");
+const { Account, Movement, MovementConfig, Network, Ed25519PrivateKey } = require("@movement-network/ts-sdk");
 ```
 
 ## Configuration
@@ -119,7 +119,7 @@ Remember to replace `YOUR_PRIVATE_KEY` with your actual private key and never sh
 The Code below is based on the [Your First Move Contract tutorial](/devs/firstMoveContract).
 
 ```javascript
-const { Account, Movement, MovementConfig, Network, Ed25519PrivateKey } = require("@moveindustries/ts-sdk");
+const { Account, Movement, MovementConfig, Network, Ed25519PrivateKey } = require("@movement-network/ts-sdk");
 
 // Define the custom network configuration
 const config = new MovementConfig({

--- a/content/docs/devs/interactonchain/wallet-adapter/connect_wallet.mdx
+++ b/content/docs/devs/interactonchain/wallet-adapter/connect_wallet.mdx
@@ -35,19 +35,19 @@ bun create next-app
 ### Install `@aptos-labs/wallet-adapter-react`
 
 ```bash tab="npm"
-npm install @aptos-labs/wallet-adapter-react @moveindustries/ts-sdk
+npm install @aptos-labs/wallet-adapter-react @movement-network/ts-sdk
 ```
 
 ```bash tab="pnpm"
-pnpm add @aptos-labs/wallet-adapter-react @moveindustries/ts-sdk
+pnpm add @aptos-labs/wallet-adapter-react @movement-network/ts-sdk
 ```
 
 ```bash tab="yarn"
-yarn add @aptos-labs/wallet-adapter-react @moveindustries/ts-sdk
+yarn add @aptos-labs/wallet-adapter-react @movement-network/ts-sdk
 ```
 
 ```bash tab="bun"
-bun add @aptos-labs/wallet-adapter-react @moveindustries/ts-sdk
+bun add @aptos-labs/wallet-adapter-react @movement-network/ts-sdk
 ```
 
 
@@ -57,7 +57,7 @@ Create a new files with name `provider/WalletProvider.tsx`, import the Aptos Wal
 ```typescript title="src/provider/WalletProvider.tsx"
 import { AptosWalletAdapterProvider } from "@aptos-labs/wallet-adapter-react";
 import { PropsWithChildren } from "react";
-import { MovementConfig, Network } from "@moveindustries/ts-sdk";
+import { MovementConfig, Network } from "@movement-network/ts-sdk";
 
 export const WalletProvider = ({ children }: PropsWithChildren) => {
   const wallets = [

--- a/content/docs/devs/interactonchain/wallet-adapter/useWallet/ConnectWallet.mdx
+++ b/content/docs/devs/interactonchain/wallet-adapter/useWallet/ConnectWallet.mdx
@@ -42,7 +42,7 @@ npx shadcn@latest add button card dialog input sonner
 Install the Movement SDK and wallet adapter packages:
 
 ```bash
-npm install @moveindustries/ts-sdk @aptos-labs/wallet-adapter-react
+npm install @movement-network/ts-sdk @aptos-labs/wallet-adapter-react
 ```
 
 ### 4. Install Wallet Standard and Peer Dependencies
@@ -65,7 +65,7 @@ Create a wallet provider component at `components/wallet-provider.tsx`:
 
 import { ReactNode } from "react";
 import { AptosWalletAdapterProvider } from "@aptos-labs/wallet-adapter-react";
-import { MovementConfig, Network } from "@moveindustries/ts-sdk";
+import { MovementConfig, Network } from "@movement-network/ts-sdk";
 
 interface WalletProviderProps {
   children: ReactNode;

--- a/content/docs/devs/interactonchain/wallet-adapter/useWallet/signAndSubmitTx.mdx
+++ b/content/docs/devs/interactonchain/wallet-adapter/useWallet/signAndSubmitTx.mdx
@@ -10,10 +10,10 @@ This React component implements a transaction signing and submission functionali
 ```typescript
 import React from 'react';
 import { useWallet } from '@aptos-labs/wallet-adapter-react';
-import { Movement, MovementConfig, Network } from '@moveindustries/ts-sdk';
+import { Movement, MovementConfig, Network } from '@movement-network/ts-sdk';
 ```
 - `@aptos-labs/wallet-adapter-react`: Provides wallet connection functionality
-- `@moveindustries/ts-sdk`: Movement blockchain SDK for interaction with the network
+- `@movement-network/ts-sdk`: Movement blockchain SDK for interaction with the network
 
 ## Configuration
 ```typescript
@@ -105,7 +105,7 @@ function App() {
 ```typescript title="src/components/signAndSubmitTx.tsx"
 import React from 'react';
 import { useWallet } from '@aptos-labs/wallet-adapter-react';
-import { Movement, MovementConfig, Network } from '@moveindustries/ts-sdk';
+import { Movement, MovementConfig, Network } from '@movement-network/ts-sdk';
 
 const config = new MovementConfig({ network: Network.MAINNET });
 const movement = new Movement(config);

--- a/content/docs/devs/movementcli.mdx
+++ b/content/docs/devs/movementcli.mdx
@@ -10,14 +10,14 @@ Movement CLI supports Aptos Move natively. Here are the instructions to install 
 Works on macOS ARM64 (M-series), macOS x86_64 (Intel), and Linux x86_64.
 
 ```bash
-brew tap moveindustries/movement
+brew tap movement-network/movement
 brew install movement
 ```
 
 Or directly:
 
 ```bash
-brew install moveindustries/movement/movement
+brew install movement-network/movement/movement
 ```
 
 Verify installation:

--- a/content/docs/devs/nameService.mdx
+++ b/content/docs/devs/nameService.mdx
@@ -20,17 +20,17 @@ MNS functionality is built into the [Movement TypeScript SDK](/devs/interactonch
 ### Installation
 
 ```bash tab="npm"
-npm install @moveindustries/ts-sdk
+npm install @movement-network/ts-sdk
 ```
 
 ```bash tab="pnpm"
-pnpm add @moveindustries/ts-sdk
+pnpm add @movement-network/ts-sdk
 ```
 
 ### Setup
 
 ```typescript
-import { Movement, MovementConfig, Network } from "@moveindustries/ts-sdk";
+import { Movement, MovementConfig, Network } from "@movement-network/ts-sdk";
 
 const config = new MovementConfig({
   network: Network.TESTNET,

--- a/content/docs/devs/tutorials/build.mdx
+++ b/content/docs/devs/tutorials/build.mdx
@@ -222,7 +222,7 @@ import { WalletSelector } from "@aptos-labs/wallet-adapter-ant-design";
 import "@aptos-labs/wallet-adapter-ant-design/dist/index.css";
 import { useRef, useState, useEffect } from "react";
 import { useWallet, InputTransactionData } from '@aptos-labs/wallet-adapter-react';
-import { Movement, MovementConfig, Network } from "@moveindustries/ts-sdk";
+import { Movement, MovementConfig, Network } from "@movement-network/ts-sdk";
 import { ONCHAIN_BIO } from "./constants";
 import './index.css';
 


### PR DESCRIPTION
DRAFT — DO NOT MERGE. Blocked on two separate migrations.

These are user-facing install instructions, so merging early breaks the docs
for every reader following them.

Blocked on the npm org rename (31 references):

- `@moveindustries/ts-sdk` -> `@movement-network/ts-sdk`
- `@moveindustries/near-intents-sdk` -> `@movement-network/near-intents-sdk`

Both `@moveindustries` packages currently exist on the npm registry and both
`@movement-network` equivalents return 404. This is gated on renaming the npm
org, which is independent of the GitHub org migration and may not happen at
the same time.

Blocked on the GitHub org migration (2 references):

- `brew tap moveindustries/movement`
- `brew install moveindustries/movement/movement`

The tap resolves to a GitHub repo, so it moves with the org.

Deliberately unchanged: the three `discord.com/invite/moveindustries` links.
That path segment is a Discord invite code, not an org name — rewriting it
would break the invites.

Re-check the npm registry and GHCR before taking this out of draft.
